### PR TITLE
Update the GitHub build workflow to use ci so that dependencies are installed based on package-lock file

### DIFF
--- a/.github/workflows/ci-fast-tooling.yml
+++ b/.github/workflows/ci-fast-tooling.yml
@@ -37,7 +37,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install Dependencies
-      run: npm install
+      run: npm ci
 
     - name: Build
       run: npm run build --if-present


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change affects the build gate and uses `npm ci` which installed from the package-lock file and should be more performant. More information about `npm ci` can be found [here](https://docs.npmjs.com/cli/v6/commands/npm-ci).

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.