### PR TITLE
Add a utility to identify the position of a dictionary item in Monaco Editor

### DIFF
--- a/packages/fast-tooling/src/data-utilities/monaco.spec.ts
+++ b/packages/fast-tooling/src/data-utilities/monaco.spec.ts
@@ -1,19 +1,22 @@
 import { expect } from "chai";
 import { IPosition } from "monaco-editor";
 import { linkedDataSchema } from "../schemas";
-import { mapDataDictionaryToMonacoEditorHTML, findMonacoEditorHTMLPositionByDictionaryId } from "./monaco";
+import {
+    mapDataDictionaryToMonacoEditorHTML,
+    findMonacoEditorHTMLPositionByDictionaryId,
+} from "./monaco";
 import { DataType, ReservedElementMappingKeyword } from "./types";
 
 const divSchema = {
     type: DataType.object,
     [ReservedElementMappingKeyword.mapsToTagName]: "div",
     properties: {
-        Slot: linkedDataSchema
-    }
+        Slot: linkedDataSchema,
+    },
 };
 const textSchema = {
     type: DataType.string,
-}
+};
 
 describe("mapDataDictionaryToMonacoEditorHTML", () => {
     it("should not map a data dictionary if no schema dictionaries conform to entries", () => {
@@ -638,17 +641,15 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                 {
                     root: {
                         schemaId: "div",
-                        data: {}
-                    }
+                        data: {},
+                    },
                 },
-                "root"
+                "root",
             ],
             {
-                div: divSchema
+                div: divSchema,
             },
-            [
-                "<div></div>"
-            ]
+            ["<div></div>"]
         );
 
         expect(position.column).to.equal(0);
@@ -664,26 +665,22 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                         data: {
                             Slot: [
                                 {
-                                    id: "foo"
-                                }
-                            ]
-                        }
+                                    id: "foo",
+                                },
+                            ],
+                        },
                     },
                     foo: {
                         schemaId: "div",
-                        data: {}
-                    }
+                        data: {},
+                    },
                 },
-                "root"
+                "root",
             ],
             {
-                div: divSchema
+                div: divSchema,
             },
-            [
-                "<div>",
-                "    <div></div>",
-                "</div>"
-            ]
+            ["<div>", "    <div></div>", "</div>"]
         );
 
         expect(position.column).to.equal(4);
@@ -699,34 +696,29 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                         data: {
                             Slot: [
                                 {
-                                    id: "foo"
+                                    id: "foo",
                                 },
                                 {
-                                    id: "bar"
-                                }
-                            ]
-                        }
+                                    id: "bar",
+                                },
+                            ],
+                        },
                     },
                     foo: {
                         schemaId: "div",
-                        data: {}
+                        data: {},
                     },
                     bar: {
                         schemaId: "div",
-                        data: {}
+                        data: {},
                     },
                 },
-                "root"
+                "root",
             ],
             {
-                div: divSchema
+                div: divSchema,
             },
-            [
-                "<div>",
-                "    <div></div>",
-                "    <div></div>",
-                "</div>"
-            ]
+            ["<div>", "    <div></div>", "    <div></div>", "</div>"]
         );
 
         expect(position.column).to.equal(4);
@@ -742,62 +734,62 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                         data: {
                             Slot: [
                                 {
-                                    id: "text1"
+                                    id: "text1",
                                 },
                                 {
-                                    id: "foo"
+                                    id: "foo",
                                 },
                                 {
-                                    id: "text2"
+                                    id: "text2",
                                 },
                                 {
-                                    id: "bar"
-                                }
-                            ]
-                        }
+                                    id: "bar",
+                                },
+                            ],
+                        },
                     },
                     text1: {
                         schemaId: "text",
-                        data: "Hello world"
+                        data: "Hello world",
                     },
                     foo: {
                         schemaId: "div",
                         data: {
                             Slot: [
                                 {
-                                    id: "text3"
-                                }
-                            ]
-                        }
+                                    id: "text3",
+                                },
+                            ],
+                        },
                     },
                     text3: {
                         schemaId: "text",
-                        data: "Hello"
+                        data: "Hello",
                     },
                     text2: {
                         schemaId: "text",
-                        data: "Hello world"
+                        data: "Hello world",
                     },
                     bar: {
                         schemaId: "div",
                         data: {
                             Slot: [
                                 {
-                                    id: "text4"
-                                }
-                            ]
-                        }
+                                    id: "text4",
+                                },
+                            ],
+                        },
                     },
                     text4: {
                         schemaId: "text",
-                        data: "world"
-                    }
+                        data: "world",
+                    },
                 },
-                "root"
+                "root",
             ],
             {
                 div: divSchema,
-                text: textSchema
+                text: textSchema,
             },
             [
                 "<div>",
@@ -805,7 +797,7 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                 "    <div>Hello</div>",
                 "    Hello world",
                 "    <div>world</div>",
-                "</div>"
+                "</div>",
             ]
         );
 
@@ -822,79 +814,79 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                         data: {
                             Slot: [
                                 {
-                                    id: "text1"
+                                    id: "text1",
                                 },
                                 {
-                                    id: "foo"
+                                    id: "foo",
                                 },
                                 {
-                                    id: "text2"
+                                    id: "text2",
                                 },
                                 {
-                                    id: "bar"
+                                    id: "bar",
                                 },
                                 {
-                                    id: "foobar"
-                                }
-                            ]
-                        }
+                                    id: "foobar",
+                                },
+                            ],
+                        },
                     },
                     text1: {
                         schemaId: "text",
-                        data: "Hello world"
+                        data: "Hello world",
                     },
                     foo: {
                         schemaId: "div",
                         data: {
                             Slot: [
                                 {
-                                    id: "text3"
-                                }
-                            ]
-                        }
+                                    id: "text3",
+                                },
+                            ],
+                        },
                     },
                     text3: {
                         schemaId: "text",
-                        data: "Hello"
+                        data: "Hello",
                     },
                     text2: {
                         schemaId: "text",
-                        data: "Hello world"
+                        data: "Hello world",
                     },
                     bar: {
                         schemaId: "div",
                         data: {
                             Slot: [
                                 {
-                                    id: "text4"
-                                }
-                            ]
-                        }
+                                    id: "text4",
+                                },
+                            ],
+                        },
                     },
                     text4: {
                         schemaId: "text",
-                        data: "world"
+                        data: "world",
                     },
                     foobar: {
                         schemaId: "div",
                         data: {
                             Slot: [
                                 {
-                                    id: "text5"
-                                }
-                            ]
-                        }
+                                    id: "text5",
+                                },
+                            ],
+                        },
                     },
                     text5: {
                         schemaId: "text",
-                        data: "foobar"
-                    }
+                        data: "foobar",
+                    },
                 },
-                "root"
+                "root",
             ],
             {
                 div: divSchema,
-                text: textSchema
+                text: textSchema,
             },
             [
                 "<div>",
@@ -902,7 +894,7 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                 "    <div>Hello</div>",
                 "    Hello world",
                 "    <div>world</div><div>foobar</div>",
-                "</div>"
+                "</div>",
             ]
         );
 
@@ -919,26 +911,22 @@ describe("findMonacoEditorHTMLPositionByDictionaryId", () => {
                         data: {
                             Slot: [
                                 {
-                                    id: "foo"
-                                }
-                            ]
-                        }
+                                    id: "foo",
+                                },
+                            ],
+                        },
                     },
                     foo: {
                         schemaId: "div",
-                        data: {}
-                    }
+                        data: {},
+                    },
                 },
-                "root"
+                "root",
             ],
             {
-                div: divSchema
+                div: divSchema,
             },
-            [
-                "<div>",
-                "    <div></div>",
-                "</div>"
-            ]
+            ["<div>", "    <div></div>", "</div>"]
         );
 
         expect(position.column).to.equal(0);

--- a/packages/fast-tooling/src/data-utilities/monaco.ts
+++ b/packages/fast-tooling/src/data-utilities/monaco.ts
@@ -5,8 +5,11 @@
  */
 
 import { get } from "lodash-es";
-import { Data, DataDictionary, SchemaDictionary } from "../message-system";
-import { ReservedElementMappingKeyword } from "./types";
+import { IPosition } from "monaco-editor";
+import { Node, parse } from "vscode-html-languageservice/lib/esm/parser/htmlParser";
+import { Data, DataDictionary, LinkedData, SchemaDictionary } from "../message-system";
+import { dictionaryLink } from "../schemas";
+import { DataType, ReservedElementMappingKeyword } from "./types";
 import { Delimiter, voidElements } from "./html-element";
 
 const whiteSpace = " ";
@@ -169,4 +172,270 @@ export function mapDataDictionaryToMonacoEditorHTML(
         schemaDictionary[dataDictionary[0][dataDictionary[1]].schemaId],
         schemaDictionary
     ).join(newline);
+}
+
+/**
+ * Find all linked data for a single data item, assuming it is an object and
+ * ignore all text children
+ */
+function findAllNonTextLinkedDataInData(
+    schema: any,
+    data: any,
+    schemaDictionary: SchemaDictionary,
+    dataDictionary: DataDictionary<unknown>
+): LinkedData[] {
+    const linkedData: LinkedData[] = [];
+
+    Object.keys(schema.properties).map((propertyName: string) => {
+        if (
+            schema.properties[propertyName][dictionaryLink] &&
+            Array.isArray(data[propertyName])
+        ) {
+            linkedData.push(
+                ...data[propertyName].filter((linkedData: LinkedData) => {
+                    return (
+                        schemaDictionary[dataDictionary[0][linkedData.id].schemaId]
+                            .type === DataType.object
+                    );
+                })
+            );
+        }
+    });
+
+    return linkedData;
+}
+
+interface StartAndEndPosition {
+    start: IPosition;
+    end: IPosition;
+}
+
+interface Position extends StartAndEndPosition {
+    matchTargetDictionaryId: boolean;
+}
+
+/**
+ * This function returns a position for each child Node.
+ */
+function getPositionFromParsedChildren(
+    parsedValue: Node,
+    dataDictionary: DataDictionary<unknown>,
+    schemaDictionary: SchemaDictionary,
+    monacoEditorLineNumberLengths: number[],
+    lineNumberLength: number,
+    targetDictionaryId: string,
+    column: number,
+    lineNumber: number,
+    childrenOfCurrentDictionaryId: LinkedData[]
+): Position {
+    // The position to be used may be updated during the following loop for any children found
+    // to account for adjacent children
+    let previousChildEnd: IPosition = {
+        lineNumber,
+        column,
+    };
+    let newPosition: Position;
+
+    // Go through the parsed values children attempting to match them to
+    // the data dictionary children
+    for (
+        let childIndex = 0, childIndexLength = parsedValue.children?.length || 0;
+        childIndex < childIndexLength;
+        childIndex++
+    ) {
+        // for each parsed value, check that item for data dictionary child items that match
+        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+        newPosition = findMonacoEditorPositionOfTheDictionaryId(
+            parsedValue.children[childIndex],
+            dataDictionary,
+            schemaDictionary,
+            monacoEditorLineNumberLengths,
+            lineNumberLength,
+            previousChildEnd.column,
+            previousChildEnd.lineNumber,
+            childrenOfCurrentDictionaryId[childIndex].id,
+            targetDictionaryId
+        );
+
+        if (newPosition?.matchTargetDictionaryId === false) {
+            previousChildEnd = {
+                column: newPosition.end.column,
+                lineNumber: newPosition.end.lineNumber,
+            };
+        } else if (newPosition?.matchTargetDictionaryId) {
+            return newPosition;
+        }
+    }
+}
+
+/**
+ * This function takes an array of numbers representing the columns of each line number,
+ * based off this and the parsed value start (or beginning of the node), the column and line number
+ * will be returned.
+ *
+ * @param monacoEditorLineNumberLengths - example [10, 20, 23]
+ * @param lineNumberLength - example 3 (see above)
+ * @param parsedValueStart - example 21
+ * @returns IPosition - example { column: 1, lineNumber: 2 }
+ */
+function getPositionFromSingleLine(
+    monacoEditorLineNumberLengths: number[],
+    lineNumberLength: number, // total lines
+    parsedValueStart: number // the start location if the HTML was on a single line
+): IPosition {
+    let totalColumns = 0; // the total number of columns so far
+
+    // go through each line
+    for (let lineNumberIndex = 0; lineNumberIndex < lineNumberLength; lineNumberIndex++) {
+        const remainingColumns = parsedValueStart - totalColumns;
+
+        // check to see if the parsedValueStart exists on this line number
+        if (
+            remainingColumns <= monacoEditorLineNumberLengths[lineNumberIndex] &&
+            remainingColumns + monacoEditorLineNumberLengths[lineNumberIndex] >
+                monacoEditorLineNumberLengths[lineNumberIndex]
+        ) {
+            return {
+                column: remainingColumns,
+                lineNumber: lineNumberIndex,
+            };
+        }
+
+        totalColumns += monacoEditorLineNumberLengths[lineNumberIndex];
+    }
+
+    return {
+        column: 0,
+        lineNumber: 0,
+    };
+}
+
+function findMonacoEditorPositionOfTheDictionaryId(
+    parsedValue: Node,
+    dataDictionary: DataDictionary<unknown>,
+    schemaDictionary: SchemaDictionary,
+    monacoEditorLineNumberLengths: number[],
+    lineNumberLength: number,
+    currentColumn: number,
+    currentLineNumber: number,
+    currentDictionaryId: string,
+    targetDictionaryId: string
+): Position {
+    const parsedValueTag = parsedValue.tag;
+    const startAndEndPositionOfDictionaryId: StartAndEndPosition = {
+        start: getPositionFromSingleLine(
+            monacoEditorLineNumberLengths,
+            lineNumberLength,
+            parsedValue.start
+        ),
+        end: getPositionFromSingleLine(
+            monacoEditorLineNumberLengths,
+            lineNumberLength,
+            parsedValue.end
+        ),
+    };
+
+    // From the current dictionary ID, determine where it is in the Monaco Editors value
+    // starting from the current column and line number
+    for (
+        let lineNumber = currentLineNumber;
+        lineNumber < lineNumberLength;
+        lineNumber++
+    ) {
+        for (
+            let column = currentLineNumber === lineNumber ? currentColumn : 0,
+                columnLength = monacoEditorLineNumberLengths[lineNumber];
+            column < columnLength;
+            column++
+        ) {
+            // match the node to the parsedValue tag
+            if (
+                schemaDictionary[dataDictionary[0][currentDictionaryId].schemaId][
+                    ReservedElementMappingKeyword.mapsToTagName
+                ] === parsedValueTag
+            ) {
+                // This is the current target dictionary id
+                if (targetDictionaryId === currentDictionaryId) {
+                    return {
+                        matchTargetDictionaryId: true,
+                        ...startAndEndPositionOfDictionaryId,
+                    };
+                    // This node has children to be parsed
+                } else if (parsedValue?.children) {
+                    // the children of this current dictionary item, without text children
+                    // which the parsed value ignores
+                    const childrenOfCurrentDictionaryId: LinkedData[] = findAllNonTextLinkedDataInData(
+                        schemaDictionary[dataDictionary[0][currentDictionaryId].schemaId],
+                        dataDictionary[0][currentDictionaryId].data,
+                        schemaDictionary,
+                        dataDictionary
+                    );
+
+                    return getPositionFromParsedChildren(
+                        parsedValue,
+                        dataDictionary,
+                        schemaDictionary,
+                        monacoEditorLineNumberLengths,
+                        lineNumberLength,
+                        targetDictionaryId,
+                        startAndEndPositionOfDictionaryId.start.column + 1,
+                        startAndEndPositionOfDictionaryId.start.lineNumber,
+                        childrenOfCurrentDictionaryId
+                    );
+                    // This is an unmatched end node
+                } else {
+                    return {
+                        matchTargetDictionaryId: false,
+                        ...startAndEndPositionOfDictionaryId,
+                    };
+                }
+            }
+        }
+    }
+
+    return {
+        matchTargetDictionaryId: false,
+        ...startAndEndPositionOfDictionaryId,
+    };
+}
+
+/**
+ * Find a Monaco Editor position from a provided dictionary ID
+ *
+ * @alpha
+ */
+export function findMonacoEditorHTMLPositionByDictionaryId(
+    dictionaryId: string,
+    dataDictionary: DataDictionary<unknown>,
+    schemaDictionary: SchemaDictionary,
+    monacoEditorValue: string[]
+): IPosition {
+    // The below numbered array represents the monaco editor column and line numbers.
+    // The parsed value will be relied on for traversing the Nodes, which only uses a single line,
+    // this numbered array will be used to re-interpret the line number and columns for the position.
+    const monacoEditorLineNumberLengths: number[] = monacoEditorValue.map(
+        (monacoEditorLine: string) => {
+            return monacoEditorLine.length;
+        }
+    );
+    const position = findMonacoEditorPositionOfTheDictionaryId(
+        parse(monacoEditorValue.join("")).roots[0],
+        dataDictionary,
+        schemaDictionary,
+        monacoEditorLineNumberLengths,
+        monacoEditorValue.length,
+        0,
+        0,
+        dataDictionary[1],
+        dictionaryId
+    );
+
+    if (position?.matchTargetDictionaryId) {
+        return position.start;
+    }
+
+    return {
+        column: 0,
+        lineNumber: 0,
+    };
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This PR adds a utility function for finding a dictionary item by ID in a Monaco Editor value. This uses the `parse` from `vscode-html-languageservice` to traverse the DOM structure and is consolidated with the `DataDictionary` which is then reinterpreted into columns and line numbers for the Monaco Editors position.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Addresses the first bullet in #53

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Check to make sure the logic and comments are clear. This may not be the most efficient solution as it traverses the complete tree until it finds the dictionary item, however optimizations may come later from the use of this function in the `MonacoAdapter` class.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Integrate this into the `MonacoAdapter`
- Test this using `MonacoAdapterAction`