### PR TITLE
add node to continuous delivery for publishing

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     if: contains('janechu,williamw2,awentzel,eisenbergeffect', github.actor)
 
+    strategy:
+      matrix:
+        node-version: [16.x]
+    
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
# Pull Request

## 📖 Description
Add Node v16+ to the GitHub Workflow such that workspaces are recognized during the testing task runner.
<!--- Provide some background and a description of your work. -->

### 🎫 Issues
Pipeline is breaking, and we believe it's because it's not specifying node 16.

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes
Will be tested via manual publish of packages.  Though, this is being used to validate so confident this will fix or at worst bring consistency across pipelines.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->