### PR TITLE
Add scroll into view to html render

### DIFF
--- a/change/@microsoft-fast-tooling-803f8205-76f4-4d44-b952-c28a6f03d3f1.json
+++ b/change/@microsoft-fast-tooling-803f8205-76f4-4d44-b952-c28a6f03d3f1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add scroll-into-view attribute to HTMLRender component.",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.ts
@@ -213,10 +213,14 @@ export class HTMLRender extends FoundationElement {
         }
         if (el) {
             this.currentElement = el;
-            if (this.scrollIntoViewOnNavigation) {
-                this.currentElement.scrollIntoView({ block: "center", inline: "center" });
-            }
             if (this.interactiveMode) {
+                if (this.scrollIntoViewOnNavigation) {
+                    this.currentElement.scrollIntoView({
+                        block: "center",
+                        inline: "center",
+                    });
+                }
+
                 this.updateLayers(
                     this.layerActivityId,
                     ActivityType.click,

--- a/packages/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.ts
@@ -1,4 +1,4 @@
-import { observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
 import { FoundationElement } from "@microsoft/fast-foundation";
 import {
@@ -47,6 +47,9 @@ export class HTMLRender extends FoundationElement {
     private activeDictionaryId: string = "";
 
     private renderLayers: HTMLRenderLayer[] = [];
+
+    @attr({ attribute: "scroll-into-view", mode: "boolean" })
+    public scrollIntoViewOnNavigation: boolean;
 
     @observable
     public interactiveMode: boolean = true;
@@ -210,6 +213,9 @@ export class HTMLRender extends FoundationElement {
         }
         if (el) {
             this.currentElement = el;
+            if (this.scrollIntoViewOnNavigation) {
+                this.currentElement.scrollIntoView({ block: "center", inline: "center" });
+            }
             if (this.interactiveMode) {
                 this.updateLayers(
                     this.layerActivityId,


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Adding a "scroll-into-view" attribute to the HTMLRender component. When the attribute is present the Renderer will scroll the selected element into view (centered in the viewport if possible) when it receives a new active dictionary id from the message system.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes #70 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->