### PR TITLE
add workspaces flag in package not yml

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Publish NPM packages
       env:
         NPM_SECRET_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: npm run publish-ci -n $NPM_SECRET_TOKEN --workspaces
+      run: npm run publish-ci -n $NPM_SECRET_TOKEN
     
     - name: Notify on Discord
       uses: appleboy/discord-action@master

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "bump": "beachball bump",
     "change": "beachball change",
     "check": "beachball check --changehint \"Run 'npm run change' to generate a change file\"",
-    "publish": "beachball publish",
-    "publish-ci": "beachball publish -y --access public",
+    "publish": "beachball publish --workspaces",
+    "publish-ci": "beachball publish -y --access public --workspaces",
     "test:diff:error": "echo \"Untracked files exist, try running npm prepare to identify the culprit.\" && exit 1",
     "test:diff": "git update-index --refresh && git diff-index --quiet HEAD -- || npm run test:diff:error",
     "test": "npm run prettier --workspaces --if-present && npm run test:diff && npm run test --workspaces --if-present"


### PR DESCRIPTION
# Pull Request

## 📖 Description
Moves `--workspaces` flag to `package.json` file under script `publish-ci` instead so that it runs as part of what's passed into npm not beachball as a command.
<!--- Provide some background and a description of your work. -->

### 🎫 Issues
Workspaces doesn't work in GH Actions because it's out of order.  I remember Beachball being very particular with where the arguments lives and this causes a different build break.
```
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
    GITHUB_SERVICE_USER: FAST DevOps
    GITHUB_SERVICE_EMAIL: fastsvc@microsoft.com
    NPM_SECRET_TOKEN: ***
npm ERR! Lifecycle script `publish-ci` failed with error: 
npm ERR! Error: Missing script: "publish-ci"
```
<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->