### PR TITLE
Allow the Navigation to scroll an active item into view when an external update is received

### DIFF
--- a/change/@microsoft-fast-tooling-react-3369fa2b-fea5-4987-86e0-eede093b5a8e.json
+++ b/change/@microsoft-fast-tooling-react-3369fa2b-fea5-4987-86e0-eede093b5a8e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow the Navigation to scroll an active item into view when an external update is received",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling-react/app/pages/navigation.tsx
+++ b/packages/fast-tooling-react/app/pages/navigation.tsx
@@ -23,6 +23,7 @@ export interface NavigationTestPageState {
     activeDictionaryId: string;
     defaultLinkedDataDroppableDataLocation: boolean;
     droppableBlocklist: string[];
+    scrollIntoView: boolean;
 }
 
 const CSSpropertyOverrides = {
@@ -63,6 +64,7 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
             activeDictionaryId: children[1],
             defaultLinkedDataDroppableDataLocation: false,
             droppableBlocklist: [],
+            scrollIntoView: false,
         };
     }
 
@@ -168,16 +170,28 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
                     </label>
                 </fieldset>
                 {this.renderAllLinkedData()}
-                <ModularNavigation
-                    messageSystem={fastMessageSystem}
-                    types={this.state.types}
-                    defaultLinkedDataDroppableDataLocation={
-                        this.state.defaultLinkedDataDroppableDataLocation
-                            ? "children"
-                            : void 0
-                    }
-                    droppableBlocklist={this.state.droppableBlocklist}
+                <input
+                    id={"scrollIntoView"}
+                    type={"checkbox"}
+                    value={this.state.scrollIntoView.toString()}
+                    onChange={this.handleScrollIntoView}
                 />
+                <label htmlFor={"scrollIntoView"}>
+                    Scroll active dictionary items into view
+                </label>
+                <div style={this.state.scrollIntoView ? { height: "100px" } : {}}>
+                    <ModularNavigation
+                        messageSystem={fastMessageSystem}
+                        types={this.state.types}
+                        defaultLinkedDataDroppableDataLocation={
+                            this.state.defaultLinkedDataDroppableDataLocation
+                                ? "children"
+                                : void 0
+                        }
+                        droppableBlocklist={this.state.droppableBlocklist}
+                        scrollIntoView={this.state.scrollIntoView}
+                    />
+                </div>
 
                 <pre>{JSON.stringify(this.state.types, null, 2)}</pre>
                 <pre>{JSON.stringify(this.state.navigation, null, 2)}</pre>
@@ -284,6 +298,12 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
     private handleCSSOverrideUpdate = (): void => {
         this.setState({
             cssPropertyOverrides: !this.state.cssPropertyOverrides,
+        });
+    };
+
+    private handleScrollIntoView = (): void => {
+        this.setState({
+            scrollIntoView: !this.state.scrollIntoView,
         });
     };
 }

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.props.ts
@@ -1,3 +1,5 @@
+import { XOR } from "@microsoft/fast-tooling/dist/dts/data-utilities/type.utilities";
+import React from "react";
 import { HoverLocation } from "./navigation.props";
 
 export enum VerticalDragDirection {
@@ -72,6 +74,11 @@ export interface NavigationTreeItemProps
      * The React ref for the input element
      */
     inputRef: React.RefObject<HTMLInputElement>;
+
+    /**
+     * The React ref for the navigation element
+     */
+    itemRef: XOR<React.RefObject<HTMLElement>, null>;
 
     /**
      * The text content

--- a/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -12,6 +12,7 @@ import {
     useDrop,
 } from "react-dnd";
 import { getHoverLocation, refNode } from "./navigation-tree-item.utilities";
+import { XOR } from "@microsoft/fast-tooling/dist/dts/data-utilities/type.utilities";
 
 function editableOverlay(
     className: string,
@@ -51,6 +52,7 @@ function treeItem(
     dictionaryId: string,
     navigationConfigId: string,
     inputRef: React.RefObject<HTMLInputElement>,
+    itemRef: XOR<React.RefObject<HTMLElement>, null>,
     ref?: (node: HTMLAnchorElement) => React.ReactElement<any>
 ): React.ReactElement {
     const displayText: React.ReactNode = isEditing
@@ -83,7 +85,7 @@ function treeItem(
           );
 
     return (
-        <span className={className}>
+        <span ref={itemRef} className={className}>
             <span className={expandTriggerClassName} onClick={handleExpandClick} />
             {displayText}
         </span>
@@ -155,6 +157,7 @@ export const NavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
     dictionaryId,
     navigationConfigId,
     inputRef,
+    itemRef,
 }: React.PropsWithChildren<NavigationTreeItemProps>): React.ReactElement => {
     return treeItem(
         handleClick,
@@ -172,7 +175,8 @@ export const NavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
         text,
         dictionaryId,
         navigationConfigId,
-        inputRef
+        inputRef,
+        itemRef
     );
 };
 
@@ -192,6 +196,7 @@ export const DraggableNavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
     isCollapsible,
     isEditing,
     inputRef,
+    itemRef,
     dragStart,
     dragEnd,
     dragHover,
@@ -262,6 +267,7 @@ export const DraggableNavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
         dictionaryId,
         navigationConfigId,
         inputRef,
+        itemRef,
         (node: HTMLSpanElement): React.ReactElement => {
             ref = node;
             return refNode(node, type, dragSource, dropTarget);

--- a/packages/fast-tooling-react/src/navigation/navigation.props.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.props.ts
@@ -170,6 +170,12 @@ export interface NavigationHandledProps {
      * @alpha
      */
     droppableBlocklist?: string[];
+
+    /**
+     * Scroll the navigation so that the active dictionary comes into view during
+     * navigation updates
+     */
+    scrollIntoView?: boolean;
 }
 
 export type NavigationProps = NavigationHandledProps;

--- a/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
+++ b/packages/fast-tooling-react/src/navigation/navigation.utilities.ts
@@ -17,6 +17,18 @@ import {
 } from "./navigation.props";
 import { DragDropItemType } from "./navigation-tree-item.props";
 
+export function isActiveItem(
+    activeDictionaryId: string,
+    dictionaryId: string,
+    activeNavigationConfigId: string,
+    navigationConfigId: string
+): boolean {
+    return (
+        activeDictionaryId === dictionaryId &&
+        activeNavigationConfigId === navigationConfigId
+    );
+}
+
 export function getDraggableItemClassName(
     isCollapsible: boolean,
     isDraggable: boolean,
@@ -43,8 +55,12 @@ export function getDraggableItemClassName(
     }
 
     if (
-        activeDictionaryId === dictionaryId &&
-        activeNavigationConfigId === navigationConfigId
+        isActiveItem(
+            activeDictionaryId,
+            dictionaryId,
+            activeNavigationConfigId,
+            navigationConfigId
+        )
     ) {
         className += ` ${navigationItemActive}`;
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change scrolls an active navigation item into view when message system updates are sent.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Resolves #52

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
There does not seem to be a good way of testing the native scroll-into-view API. This will have to be revisited after some work regarding integration testing using the manual testing apps.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.