### PR TITLE
Attempt to address workflow permissions issue when commiting to main branch

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -24,6 +24,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ env.GITHUB_TOKEN }}
+        persist-credentials: false
 
     - name: Set Git User
       run: |


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
According to the top answer https://stackoverflow.com/questions/63733822/cant-push-to-protected-branch-in-github-action with this same error we are seeing with the validator, the actions/checkout@v2 may be overriding the git permissions we have set up. This could be causing the error when attempting to push commits to the main branch.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.