### PR TITLE
Update workflow to use a GitHub PAT for pushing changes to a protected branch

### DIFF
--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -6,7 +6,7 @@ on:
     - cron: '0 7 * * 0-4'
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   GITHUB_SERVICE_USER: "FAST DevOps"
   GITHUB_SERVICE_EMAIL: "fastsvc@microsoft.com"
       
@@ -24,7 +24,6 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ env.GITHUB_TOKEN }}
-        persist-credentials: false
 
     - name: Set Git User
       run: |

--- a/.github/workflows/cd-publish.yml
+++ b/.github/workflows/cd-publish.yml
@@ -9,7 +9,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
   GITHUB_SERVICE_USER: "FAST DevOps"
   GITHUB_SERVICE_EMAIL: "fastsvc@microsoft.com"
-      
+
 jobs:
   build_linux:
     runs-on: ubuntu-latest

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -48,11 +48,16 @@ npm run bump
 ```
 
 ## NPM Authentication Best Practices
-1. Publishing with an NPM Token should be configured to "Require two-factor authentication or automation tokens from the `fastsvc@microsoft.com` service account which uses the Authenticator App for 2FA, if needed for manual publishing, otherwise automation skips 2FA.
+1. Publishing with an NPM Token should be configured to require two-factor authentication or automation tokens from the `fastsvc@microsoft.com` service account which uses the Authenticator App for 2FA, if needed for manual publishing, otherwise automation skips 2FA.
 2. When creating the new NPM Access Token select the "Automation" type which will then bypass 2FA from the workflow.
 3. Add this token to GitHub Secrets as `NPM_TOKEN`.
 4. Always include `registry-url: 'https://registry.npmjs.org'` on `actions/setup-node@v1` runner, in the YAML workflow file, even though it feels like it should be the default.
-5. Always set `NODE_AUTH_TOKEN: $ {{ secrets.NPM_TOKEN }}` to minimize authentication issues. This will automatically create the correct `.npmrc` configuration for the workflow.
+5. Always set `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to minimize authentication issues. This will automatically create the correct `.npmrc` configuration for the workflow.
+
+## GIT Authentication Best Practices
+1. Automated committing to a protected branch such as `main` should require configuration to use a PAT (Personal Access Token) from a user with sufficient security clearance.
+2. This token should be added to the repositories GitHub Secrets as `GH_TOKEN`.
+3. The token can then be referred to in GitHub workflows as `GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}`.
 
 ## Publishing Resources
 - [Hackernoon](https://hackernoon.com/publish-npm-packages-using-github-actions-a-how-to-guide-q31c34fg)


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Due to the face that the default `GITHUB_TOKEN` available to GitHub actions cannot push commits to protected branches, a new PAT has been added to the repository and referenced in the workflow. This should allow publish commits and tags to be pushed by the workflow.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
The documentation from GitHub indicates that for extra permissions, this is the only solution, see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#granting-additional-permissions

The permissions that the `GITHUB_TOKEN` does not cover includes git actions such as pushing commits, so there is no way to grant the generated token write access.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.