### PR TITLE
Remove the soft remove UI for linked data

### DIFF
--- a/change/@microsoft-fast-tooling-react-7498ea63-c028-4425-a254-9ad0097498aa.json
+++ b/change/@microsoft-fast-tooling-react-7498ea63-c028-4425-a254-9ad0097498aa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove the soft remove UI for linked data as this should only be for regular JSON schema defined data types",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling-react/src/form/templates/template.control.utilities.spec.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.utilities.spec.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import Adapter from "enzyme-adapter-react-16";
+import "../../__tests__/mocks/match-media";
 import { configure, mount, shallow } from "enzyme";
 import ControlTemplateUtilities from "./template.control.utilities";
 import { BadgeType } from "./types";
 import defaultStrings from "../form.strings";
+import { ControlType } from "../";
 
 /*
  * Configure Enzyme
@@ -38,6 +40,17 @@ describe("ControlPlugin", () => {
         );
 
         expect(renderSoftRemove.find("SoftRemove")).toHaveLength(1);
+    });
+    test("should not render a soft remove trigger if the data type is linkedData", () => {
+        const testClass: TestClass = new TestClass({
+            ...config,
+            softRemove: true,
+            type: ControlType.linkedData,
+        });
+
+        const renderSoftRemove: any = testClass.renderSoftRemove("foo");
+
+        expect(renderSoftRemove).toEqual(void 0);
     });
     test("should render a badge if the badge prop is passed", () => {
         const testClass: TestClass = new TestClass({

--- a/packages/fast-tooling-react/src/form/templates/template.control.utilities.tsx
+++ b/packages/fast-tooling-react/src/form/templates/template.control.utilities.tsx
@@ -35,7 +35,11 @@ abstract class ControlTemplateUtilities<P, S> extends React.Component<
     }
 
     public renderSoftRemove(className: string): React.ReactNode {
-        if (!this.props.required && this.props.softRemove) {
+        if (
+            !this.props.required &&
+            this.props.softRemove &&
+            this.props.type !== ControlType.linkedData
+        ) {
             return (
                 <SoftRemove
                     className={className}


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes the soft remove (or undo/redo) button from the linked data control. It has been determined that this UI is confusing and would be confusing to maintain for linked data, which is a special data case outside of the regular data types defined in JSON schema.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
