### PR TITLE
Fix CSS Box Model change event propagation

### DIFF
--- a/change/@microsoft-fast-tooling-ac53af37-67ac-4363-9ee4-6b05f03248d6.json
+++ b/change/@microsoft-fast-tooling-ac53af37-67ac-4363-9ee4-6b05f03248d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixes change event propagation in CSSBoxModel",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/css-box-model/css-box-model.ts
+++ b/packages/fast-tooling/src/web-components/css-box-model/css-box-model.ts
@@ -264,7 +264,7 @@ export class CSSBoxModel extends FormAssociatedCSSBoxModel {
      * @param e The event object.
      * @returns false
      */
-    public handleInputChange(param: string, e: Event) {
+    public handleInputChange = (param: string, e: Event) => {
         // get the mapping and the new value
         const mapping = CSSToUIValueMapping[param];
         const inputVal = (e.composedPath()[0] as HTMLInputElement).value;
@@ -280,10 +280,11 @@ export class CSSBoxModel extends FormAssociatedCSSBoxModel {
         this.internalChange = true;
         // set the initialValue to the css string for the updated value
         this.initialValue = this.buildCSSStyles();
+        e.stopPropagation();
         // emit the change event
         this.$emit("change");
         return false;
-    }
+    };
 
     /**
      * Parses a css style string and sets the uiValues values.


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Add stopPropagation() to change event in CSS Box Model to prevent double change events.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->