### PR TITLE
Fix Html Render Inline Edit empty string bug

### DIFF
--- a/change/@microsoft-fast-tooling-33edb3ae-17d9-44c1-a904-71ea39a78c76.json
+++ b/change/@microsoft-fast-tooling-33edb3ae-17d9-44c1-a904-71ea39a78c76.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed inline edit vanishing when text is empty",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This fixes a problem with calculating the correct size and position of the inline edit text area when all of the text is removed that would result in the text area vanishing and losing focus.
This fix introduces a new minimum size for the text area calculated from the target text node's calculated line-height or in the case line-height returns "normal" it is 1.5x the calculated font-size (which always returns a pixel value).

**This will not be fully fixed until https://github.com/microsoft/fast-creator/pull/85 is merged.**

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes: #74 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->