### PR TITLE
Fix whitespace bug in Inline Edit

### DIFF
--- a/change/@microsoft-fast-tooling-ac490369-62c4-4e2a-ac51-bde87aa2dba7.json
+++ b/change/@microsoft-fast-tooling-ac490369-62c4-4e2a-ac51-bde87aa2dba7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed inline edit whitespace bug",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.style.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.style.ts
@@ -24,7 +24,6 @@ export const htmlRenderLayerInlineEditStyles = css`
         padding: 0;
         background: white;
         caret-color: black;
-        overflow: hidden;
         resize: none;
         outline: 1px solid black;
         white-space: pre-wrap;

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
@@ -97,7 +97,7 @@ export class HTMLRenderLayerInlineEdit extends HTMLRenderLayer {
 
         // Make sure the text node always has at least one character in it othewise we lose
         // positioning and size.
-        this.currentTextNode.textContent = inputVal.length === 0 ? "W" : inputVal;
+        this.currentTextNode.textContent = inputVal.trim().length === 0 ? "W" : inputVal;
         this.applySizeAndPositionToTextbox();
         if (this.activityCallback) {
             this.activityCallback(this.layerActivityId, ActivityType.update);
@@ -124,12 +124,14 @@ export class HTMLRenderLayerInlineEdit extends HTMLRenderLayer {
         this.textAreaRef.style.width = `${
             this.currentMinimumSize > this.textPosition.width
                 ? this.currentMinimumSize
-                : this.textPosition.width
+                : this.textPosition.width + 2
         }px`;
         this.textAreaRef.style.height = `${
             this.currentMinimumSize > this.textPosition.height
                 ? this.currentMinimumSize
-                : this.textPosition.height
+                : this.textAreaRef.scrollHeight > this.textPosition.height
+                ? this.textAreaRef.scrollHeight
+                : this.textPosition.height + 2
         }px`;
     }
 
@@ -159,7 +161,7 @@ export class HTMLRenderLayerInlineEdit extends HTMLRenderLayer {
         this.currentDataId = datadictionaryId;
         this.currentTextNode = elementRef;
 
-        this.textValue = this.dataDictionary[0][datadictionaryId].data as string;
+        this.textValue = (this.dataDictionary[0][datadictionaryId].data as string).trim();
         this.originalTextValue = this.textValue;
         const path: EventTarget[] = event.composedPath();
         let i = 0;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Making adjustments to better handle the sizing of the text area when white space is present in the original text or when the user types a string that is empty except for whitespace. Also improves the text area height and width logic to reduce instances where the line wrapping happens differently in the textarea vs the underlying element.

<!--- Provide some background and a description of your work. -->

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->