### PR TITLE
Adds the dictionary ID of the dictionary item being edited to outgoing messages from the message system and the inline editing component

### DIFF
--- a/change/@microsoft-fast-tooling-e7c79a35-9f93-4bd4-82e5-fe777fc83879.json
+++ b/change/@microsoft-fast-tooling-e7c79a35-9f93-4bd4-82e5-fe777fc83879.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds the dictionary ID of the dictionary item being edited to outgoing messages from the message system and the inline editing component",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -279,6 +279,7 @@ export interface UpdateDataMessageOutgoing<TConfig = {}>
     extends ArbitraryMessageOutgoing<TConfig> {
     type: MessageSystemType.data;
     action: MessageSystemDataTypeAction.update;
+    dictionaryId: string;
     data: unknown;
     dataDictionary: DataDictionary<unknown>;
     navigation: NavigationConfig;

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -401,6 +401,7 @@ describe("getMessage", () => {
             ) as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "venus" });
+            expect(message[0].dictionaryId).to.equal("data");
         });
         it("should return a data blob with updated values when a dictionaryId has been specified", () => {
             getMessage([
@@ -439,6 +440,7 @@ describe("getMessage", () => {
             ) as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "venus" });
+            expect(message[0].dictionaryId).to.equal("bar");
             expect(message[0].dataDictionary).to.deep.equal([
                 {
                     foo: {

--- a/packages/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.ts
@@ -295,6 +295,7 @@ function getDataMessage(data: DataMessageIncoming): DataMessageOutgoing {
             return {
                 type: MessageSystemType.data,
                 action: MessageSystemDataTypeAction.update,
+                dictionaryId,
                 data: dataDictionary[0][dictionaryId].data,
                 dataDictionary,
                 navigation: navigationDictionary[0][dictionaryId],

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
@@ -202,6 +202,7 @@ export class HTMLRenderLayerInlineEdit extends HTMLRenderLayer {
             type: MessageSystemType.data,
             action: MessageSystemDataTypeAction.update,
             dataLocation: "",
+            dictionaryId: this.currentDataId,
             data: newValue,
             options: {
                 originatorId: htmlRenderOriginatorId,


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change updates the following:

- Adds the dictionary ID being edited to the data update sent by the inline editing control, this was assumed to be the active dictionary ID and was therefore not specified but this may cause async navigational issues
- Adds the dictionary ID to the message systems data updates for further information to message system handlers

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.