### PR TITLE
Fix Navigation pill preview bug

### DIFF
--- a/change/@microsoft-fast-tooling-18696111-00f0-4b88-ac38-6b820013ddef.json
+++ b/change/@microsoft-fast-tooling-18696111-00f0-4b88-ac38-6b820013ddef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed Navigation pill preview bug",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.template.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.template.ts
@@ -12,7 +12,7 @@ export const htmlRenderLayerNavigationTemplate: (
                 class="navigation-select${x =>
                     x.selectLayerActive && !x.selectLayerHide
                         ? " navigation-select__active"
-                        : null}
+                        : ""}
                         ${x =>
                     x.selectPosition.top === 0 ? " navigation-select__insetY" : ""}
                         ${x =>
@@ -40,7 +40,7 @@ export const htmlRenderLayerNavigationTemplate: (
                 class="navigation-hover ${x =>
                     x.hoverLayerActive && !x.hoverLayerHide
                         ? "navigation-hover__active"
-                        : null}"
+                        : ""}"
                 style="top:${x => x.hoverPosition.top}px;left:${x =>
                     x.hoverPosition.left}px;width:${x =>
                     x.hoverPosition.width}px;height:${x => x.hoverPosition.height}px"


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Previous work in the HTMLRender Navigation component caused a regression which was preventing the correct style class name from being applied in "preview" mode which caused the navigation pill to still be visible.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->