### PR TITLE
Fix html render empty markup bug

### DIFF
--- a/change/@microsoft-fast-tooling-5e290551-ffbb-455f-9cc2-5b9f0d815f0f.json
+++ b/change/@microsoft-fast-tooling-5e290551-ffbb-455f-9cc2-5b9f0d815f0f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed HTMLRender error on empty markup",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.ts
@@ -469,9 +469,12 @@ export class HTMLRender extends FoundationElement {
 
     /// Render
 
-    private renderHtmlResolver = (config: ResolverConfig<any>): HTMLElement | Text => {
+    private renderHtmlResolver = (
+        config: ResolverConfig<any>
+    ): HTMLElement | Text | null => {
         htmlResolver(config);
         if (
+            config.dataDictionary[0][config.dictionaryId].data !== undefined &&
             (config.dataDictionary[0][config.dictionaryId].data as HTMLElement)
                 .setAttribute
         ) {
@@ -485,8 +488,10 @@ export class HTMLRender extends FoundationElement {
                 "taborder",
                 (this.tabCounter++).toString()
             );
+            return config.dataDictionary[0][config.dictionaryId].data;
+        } else {
+            return null;
         }
-        return config.dataDictionary[0][config.dictionaryId].data;
     };
 
     public renderMarkup(): void {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
Fixes a bug in HTMLRender component that would throw a javascript error and place the renderer into an unrecoverable state when given a data dictionary with no markup.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->