### PR TITLE
Fixed an issue where indenting whitespace was interpreted as a text node

### DIFF
--- a/change/@microsoft-fast-tooling-4e832163-9384-479d-8cc2-d3a4a201d923.json
+++ b/change/@microsoft-fast-tooling-4e832163-9384-479d-8cc2-d3a4a201d923.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue where indenting whitespace was interpreted as a text node",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/fast-tooling/src/message-system-service/monaco-adapter.service.ts
@@ -154,7 +154,12 @@ export class MonacoAdapter extends MessageSystemService<
 
         if (!isExternal) {
             const dataDictionary = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
-                this.monacoModelValue.join("").replace(/\n/g, ""),
+                this.monacoModelValue
+                    .map((value: string): string => {
+                        return value.replace(/^\s+/g, ""); // replace leading spaces on each line
+                    })
+                    .join("")
+                    .replace(/\n/g, ""),
                 "text",
                 this.dataDictionary,
                 this.schemaDictionary


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This fixes an issue where, when typing inside an instance of the Monaco Editor, the whitespaces at the beginning of the values which are only used as indenting, were being interpreted as text nodes.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Try typing in the Monaco Editor, this should no longer show as multiple elements and empty text nodes.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.