### PR TITLE
Adding example pages for components that didn't have one

### DIFF
--- a/change/@microsoft-fast-tooling-66cace99-f127-40a7-9904-ed017826d40c.json
+++ b/change/@microsoft-fast-tooling-66cace99-f127-40a7-9904-ed017826d40c.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Added example pages for components that didn't have one.",
   "packageName": "@microsoft/fast-tooling",
   "email": "44823142+williamw2@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@microsoft-fast-tooling-66cace99-f127-40a7-9904-ed017826d40c.json
+++ b/change/@microsoft-fast-tooling-66cace99-f127-40a7-9904-ed017826d40c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Added example pages for components that didn't have one.",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/app/examples/color-picker/index.html
+++ b/packages/fast-tooling/app/examples/color-picker/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title><%= htmlWebpackPlugin.options.title %></title>
+        <style>
+            html,
+            body,
+            #root {
+                width: 100%;
+                height: 100%;
+                font-family: Arial, Helvetica, sans-serif;
+                background-color: var(--fill-color);
+                padding: 20px;
+                color: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="root">
+            <fast-tooling-color-picker id="color_picker"></fast-tooling-color-picker>
+            <br />
+            Output:
+            <input id="outputValue" type="text" style="width: 800px;" />
+        </div>
+        <script>
+            const colorPickerElement = document.getElementById("color_picker");
+            const outputVal = document.getElementById("outputValue");
+
+            colorPickerElement.addEventListener("change", e => {
+                outputVal.value = e.target.value;
+            });
+        </script>
+    </body>
+</html>

--- a/packages/fast-tooling/app/examples/color-picker/index.ts
+++ b/packages/fast-tooling/app/examples/color-picker/index.ts
@@ -1,0 +1,8 @@
+import { provideFASTDesignSystem } from "@microsoft/fast-components";
+import { fastTextField } from "@microsoft/fast-components";
+import { fastToolingColorPicker } from "../../../src/web-components/color-picker";
+
+provideFASTDesignSystem()
+    .register(fastTextField())
+    .withPrefix("fast-tooling")
+    .register(fastToolingColorPicker());

--- a/packages/fast-tooling/app/examples/color-picker/webpack.common.cjs
+++ b/packages/fast-tooling/app/examples/color-picker/webpack.common.cjs
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const path = require("path");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+const appDir = path.resolve(__dirname, "./");
+const outDir = path.resolve(__dirname, "./www");
+
+module.exports = {
+    name: "color-picker",
+    entry: {
+        main: path.resolve(appDir, "index.ts"),
+    },
+    resolve: {
+        extensions: [".ts", ".js"],
+    },
+    output: {
+        path: outDir,
+        publicPath: "/",
+    },
+    module: {
+        // where we defined file patterns and their loaders
+        rules: [
+            {
+                test: /.ts$/,
+                use: [
+                    {
+                        loader: "ts-loader",
+                    },
+                ],
+            },
+            {
+                test: /\.(svg|png|jpe?g|gif|ttf)$/i,
+                use: {
+                    loader: "file-loader",
+                    options: {
+                        esModule: false,
+                    },
+                },
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            hmr: process.env.NODE_ENV === "development",
+                        },
+                    },
+                    {
+                        loader: "css-loader",
+                    },
+                ],
+            },
+            {
+                test: /message\-system\.min\.js/,
+                use: {
+                    loader: "worker-loader",
+                },
+            },
+        ],
+    },
+    plugins: [
+        new CleanWebpackPlugin(),
+        new MiniCssExtractPlugin(),
+        new HtmlWebpackPlugin({
+            title: "FAST tooling test application",
+            inject: "body",
+            template: path.resolve(appDir, "index.html"),
+        }),
+    ],
+};

--- a/packages/fast-tooling/app/examples/color-picker/webpack.dev.cjs
+++ b/packages/fast-tooling/app/examples/color-picker/webpack.dev.cjs
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const merge = require("webpack-merge");
+const baseConfig = require("./webpack.common.cjs");
+
+module.exports = merge(baseConfig, {
+    devServer: {
+        port: 3003,
+    },
+    mode: "development",
+    output: {
+        filename: "[name].js",
+    },
+});

--- a/packages/fast-tooling/app/examples/file/index.html
+++ b/packages/fast-tooling/app/examples/file/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title><%= htmlWebpackPlugin.options.title %></title>
+        <style>
+            html,
+            body,
+            #root {
+                width: 100%;
+                height: 100%;
+                font-family: Arial, Helvetica, sans-serif;
+                background-color: var(--fill-color);
+                padding: 20px;
+                color: white;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="root">
+            <fast-tooling-file id="file" accept=".jpg,.jpeg,.gif,.png">
+                Pick a file
+                <fast-tooling-file-action-objecturl
+                    role="fileaction"
+                    slot="action"
+                ></fast-tooling-file-action-objecturl>
+            </fast-tooling-file>
+            <br />
+            Output:
+            <input id="outputValue" type="text" style="width: 800px;" />
+            <br />
+            <img id="outputImg" />
+        </div>
+        <script>
+            const fileElement = document.getElementById("file");
+            const outputVal = document.getElementById("outputValue");
+            const outputImg = document.getElementById("outputImg");
+
+            fileElement.addEventListener("change", e => {
+                outputVal.value = e.target.fileReferences[0];
+                outputImg.src = e.target.fileReferences[0];
+            });
+        </script>
+    </body>
+</html>

--- a/packages/fast-tooling/app/examples/file/index.ts
+++ b/packages/fast-tooling/app/examples/file/index.ts
@@ -1,0 +1,10 @@
+import { provideFASTDesignSystem } from "@microsoft/fast-components";
+import { fastButton } from "@microsoft/fast-components";
+import { fastToolingFile } from "../../../src/web-components/file";
+import { fastToolingFileActionObjectUrl } from "../../../src/web-components/file-action-objecturl";
+
+provideFASTDesignSystem()
+    .register(fastButton())
+    .withPrefix("fast-tooling")
+    .register(fastToolingFile())
+    .register(fastToolingFileActionObjectUrl());

--- a/packages/fast-tooling/app/examples/file/webpack.common.cjs
+++ b/packages/fast-tooling/app/examples/file/webpack.common.cjs
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const path = require("path");
+const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+
+const appDir = path.resolve(__dirname, "./");
+const outDir = path.resolve(__dirname, "./www");
+
+module.exports = {
+    name: "file",
+    entry: {
+        main: path.resolve(appDir, "index.ts"),
+    },
+    resolve: {
+        extensions: [".ts", ".js"],
+    },
+    output: {
+        path: outDir,
+        publicPath: "/",
+    },
+    module: {
+        // where we defined file patterns and their loaders
+        rules: [
+            {
+                test: /.ts$/,
+                use: [
+                    {
+                        loader: "ts-loader",
+                    },
+                ],
+            },
+            {
+                test: /\.(svg|png|jpe?g|gif|ttf)$/i,
+                use: {
+                    loader: "file-loader",
+                    options: {
+                        esModule: false,
+                    },
+                },
+            },
+            {
+                test: /\.css$/,
+                use: [
+                    {
+                        loader: MiniCssExtractPlugin.loader,
+                        options: {
+                            hmr: process.env.NODE_ENV === "development",
+                        },
+                    },
+                    {
+                        loader: "css-loader",
+                    },
+                ],
+            },
+            {
+                test: /message\-system\.min\.js/,
+                use: {
+                    loader: "worker-loader",
+                },
+            },
+        ],
+    },
+    plugins: [
+        new CleanWebpackPlugin(),
+        new MiniCssExtractPlugin(),
+        new HtmlWebpackPlugin({
+            title: "FAST tooling test application",
+            inject: "body",
+            template: path.resolve(appDir, "index.html"),
+        }),
+    ],
+};

--- a/packages/fast-tooling/app/examples/file/webpack.dev.cjs
+++ b/packages/fast-tooling/app/examples/file/webpack.dev.cjs
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const merge = require("webpack-merge");
+const baseConfig = require("./webpack.common.cjs");
+
+module.exports = merge(baseConfig, {
+    devServer: {
+        port: 3003,
+    },
+    mode: "development",
+    output: {
+        filename: "[name].js",
+    },
+});

--- a/packages/fast-tooling/app/examples/render/index.html
+++ b/packages/fast-tooling/app/examples/render/index.html
@@ -16,6 +16,13 @@
                 border: 1px solid black;
                 padding: 15px;
             }
+            #htmlRender {
+                display: block;
+                height: 200px;
+            }
+            #messageContainer span {
+                display: block;
+            }
         </style>
     </head>
     <body>
@@ -26,7 +33,12 @@
                 <fast-tooling-html-render-layer-navigation
                     role="htmlrenderlayer"
                 ></fast-tooling-html-render-layer-navigation>
+                <fast-tooling-html-render-layer-inline-edit
+                    role="htmlrenderlayer"
+                ></fast-tooling-html-render-layer-inline-edit>
             </fast-tooling-html-render>
+            <br />
+            <div id="messageContainer"></div>
         </div>
     </body>
 </html>

--- a/packages/fast-tooling/app/examples/render/index.ts
+++ b/packages/fast-tooling/app/examples/render/index.ts
@@ -1,19 +1,25 @@
 import { DesignSystem } from "@microsoft/fast-foundation";
 import {
     MessageSystem,
+    MessageSystemDataTypeAction,
     MessageSystemNavigationTypeAction,
     MessageSystemType,
 } from "../../../src";
 import { HTMLRender } from "../../../src/web-components/html-render/html-render";
 import { fastToolingHTMLRender } from "../../../src/web-components/html-render";
 import { fastToolingHTMLRenderLayerNavigation } from "../../../src/web-components/html-render-layer-navigation";
+import { fastToolingHTMLRenderLayerInlineEdit } from "../../../src/web-components/html-render-layer-inline-edit";
 import { nativeElementDefinitions } from "../../../src/definitions/";
 import dataDictionaryConfig from "../../../src/__test__/html-render/data-dictionary-config";
 import schemaDictionary from "../../../src/__test__/html-render/schema-dictionary";
 
 DesignSystem.getOrCreate()
     .withPrefix("fast-tooling")
-    .register(fastToolingHTMLRender(), fastToolingHTMLRenderLayerNavigation());
+    .register(
+        fastToolingHTMLRender(),
+        fastToolingHTMLRenderLayerNavigation(),
+        fastToolingHTMLRenderLayerInlineEdit()
+    );
 
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */
 const FASTMessageSystemWorker = require("../../../dist/message-system.min.js");
@@ -25,6 +31,7 @@ let fastMessageSystem: MessageSystem;
 const htmlRender: HTMLRender = document.getElementById("htmlRender") as HTMLRender;
 const button1: HTMLElement = document.getElementById("testbutton1");
 const button2: HTMLElement = document.getElementById("testbutton2");
+const messageContainer: HTMLElement = document.getElementById("messageContainer");
 
 function handleMessageSystem(e: MessageEvent) {
     if (e.data) {
@@ -32,7 +39,11 @@ function handleMessageSystem(e: MessageEvent) {
             e.data.type === MessageSystemType.initialize ||
             e.data.type === MessageSystemType.data
         ) {
-            /**Initialize stuff here */
+            if (e.data.action === MessageSystemDataTypeAction.update) {
+                UpdateMessageContainer(
+                    `Inline Edit: ${e.data.dictionaryId} = ${e.data.data}`
+                );
+            }
         }
 
         if (e.data.type === MessageSystemType.initialize) {
@@ -43,9 +54,15 @@ function handleMessageSystem(e: MessageEvent) {
             e.data.action === MessageSystemNavigationTypeAction.update &&
             e.data.activeNavigationConfigId !== "foo"
         ) {
-            console.log("Message Recieved", e.data);
+            UpdateMessageContainer(`Navigation: ${e.data.activeDictionaryId}`);
         }
     }
+}
+
+function UpdateMessageContainer(text: string) {
+    const span = document.createElement("span");
+    span.innerHTML = text;
+    messageContainer.appendChild(span);
 }
 
 if ((window as any).Worker) {

--- a/packages/fast-tooling/app/index.html
+++ b/packages/fast-tooling/app/index.html
@@ -56,17 +56,17 @@
                     </button>
                 </li>
                 <li>
-                    <button onclick="updateIframeSrc('render')">
-                        <code>
-                            Render
-                        </code>
-                    </button>
-                </li>
-                <li>
                     <code>
                         Web components
                     </code>
                     <ul>
+                        <li>
+                            <button onclick="updateIframeSrc('css-box-model')">
+                                <code>
+                                    CSS Box Model
+                                </code>
+                            </button>
+                        </li>
                         <li>
                             <button onclick="updateIframeSrc('css-layout')">
                                 <code>
@@ -75,16 +75,30 @@
                             </button>
                         </li>
                         <li>
-                            <button onclick="updateIframeSrc('units-text-field')">
+                            <button onclick="updateIframeSrc('color-picker')">
                                 <code>
-                                    Units Text Field
+                                    Color Picker
                                 </code>
                             </button>
                         </li>
                         <li>
-                            <button onclick="updateIframeSrc('css-box-model')">
+                            <button onclick="updateIframeSrc('file')">
                                 <code>
-                                    CSS Box Model
+                                    File
+                                </code>
+                            </button>
+                        </li>
+                        <li>
+                            <button onclick="updateIframeSrc('render')">
+                                <code>
+                                    HTML Render
+                                </code>
+                            </button>
+                        </li>
+                        <li>
+                            <button onclick="updateIframeSrc('units-text-field')">
+                                <code>
+                                    Units Text Field
                                 </code>
                             </button>
                         </li>

--- a/packages/fast-tooling/src/__test__/html-render/data-dictionary-config.ts
+++ b/packages/fast-tooling/src/__test__/html-render/data-dictionary-config.ts
@@ -10,7 +10,7 @@ export default [
                         id: "span",
                     },
                 ],
-                style: "border:1px solid black;padding:15px;",
+                style: "border:1px solid black;padding:30px;",
             },
         },
         span: {

--- a/packages/fast-tooling/src/__test__/html-render/schema-dictionary.ts
+++ b/packages/fast-tooling/src/__test__/html-render/schema-dictionary.ts
@@ -27,6 +27,7 @@ export default {
         $id: "span",
         id: "span",
         type: "object",
+        title: "span",
         [ReservedElementMappingKeyword.mapsToTagName]: "span",
         properties: {
             Slot: {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->

Adding example pages for the color picker and file components and updating the HTML Render example to include the Inline Edit component.
The File component example includes the file-action-objurl component as the file-action is more of an interface definition and components implementing it are not intended for use outside of a File component. Additional File example routes may be added when new file-action components are added. 
The HTML Render example button has been moved and re-labeled and updated to include the html-render-layer-inline-edit component. The html-render-layer, html-render-layer-inline-edit and html-render-layer-navigation components are not intended to be used outside of html-render and are included in the html-render route.
I also re-ordered the buttons in the web component section of the app/index.html to be ordered alphabetically. 

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes: #96 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->