### PR TITLE
Allow remove linked data messages to remove the current active dictionary ID

### DIFF
--- a/change/@microsoft-fast-tooling-d3de2ecd-f47d-41da-939a-8d382c850222.json
+++ b/change/@microsoft-fast-tooling-d3de2ecd-f47d-41da-939a-8d382c850222.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Allow remove linked data messages to remove the current active dictionary ID",
+  "comment": "Added behavior to the remove linked data messages to remove the current active dictionary ID when no other information is provided",
   "packageName": "@microsoft/fast-tooling",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-tooling-d3de2ecd-f47d-41da-939a-8d382c850222.json
+++ b/change/@microsoft-fast-tooling-d3de2ecd-f47d-41da-939a-8d382c850222.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow remove linked data messages to remove the current active dictionary ID",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/message-system/data.ts
+++ b/packages/fast-tooling/src/message-system/data.ts
@@ -130,7 +130,7 @@ export function getLinkedData(
 }
 
 /**
- * Gets a list of linked data ids from a single dictionary id
+ * Gets a list of child linked data ids from a single dictionary id
  */
 export function getLinkedDataList(
     dataDictionary: DataDictionary<unknown>,

--- a/packages/fast-tooling/src/message-system/errors.ts
+++ b/packages/fast-tooling/src/message-system/errors.ts
@@ -1,0 +1,2 @@
+export const removeRootDataNodeErrorMessage =
+    "An attempt was made to remove the root dictionary item.";

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -334,8 +334,8 @@ export interface RemoveLinkedDataDataMessageIncoming<TConfig = {}>
      * active dictionary ID
      */
     dictionaryId?: string;
-    dataLocation: string;
-    linkedData: LinkedData[];
+    dataLocation?: string;
+    linkedData?: LinkedData[];
 }
 
 /**
@@ -573,6 +573,14 @@ export interface CustomMessageIncomingOutgoing<OConfig>
 }
 
 /**
+ * The message that an error occured when attempting to perform an action
+ */
+export interface ErrorMessageOutgoing {
+    type: MessageSystemType.error;
+    message: string;
+}
+
+/**
  * The custom message interface
  */
 export type CustomMessage<T, OConfig> = CustomMessageIncomingOutgoing<OConfig> & T;
@@ -688,6 +696,7 @@ export type InternalMessageSystemIncoming<C = {}, OConfig = {}> =
 export type MessageSystemOutgoing<C = {}, OConfig = {}> =
     | InitializeMessageOutgoing
     | DataMessageOutgoing
+    | ErrorMessageOutgoing
     | HistoryMessageOutgoing
     | SchemaDictionaryMessageOutgoing
     | NavigationMessageOutgoing
@@ -703,6 +712,7 @@ export type MessageSystemOutgoing<C = {}, OConfig = {}> =
 export type InternalMessageSystemOutgoing<C = {}, OConfig = {}> =
     | InternalOutgoingMessage<InitializeMessageOutgoing>
     | InternalOutgoingMessage<DataMessageOutgoing>
+    | InternalOutgoingMessage<ErrorMessageOutgoing>
     | InternalOutgoingMessage<HistoryMessageOutgoing>
     | InternalOutgoingMessage<SchemaDictionaryMessageOutgoing>
     | InternalOutgoingMessage<NavigationMessageOutgoing>

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -1149,7 +1149,6 @@ describe("getMessage", () => {
 
             expect(message[0].type).to.equal(MessageSystemType.error);
             expect((message[0] as any).message).to.equal(removeRootDataNodeErrorMessage);
-            console.log("message", message);
         });
         it("should reorder linkedData in the exist array of linkedData items", () => {
             getMessage([

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -35,6 +35,7 @@ import { getMessage } from "./message-system.utilities";
 import { Data, DataDictionary, LinkedData } from "./data.props";
 import { SchemaDictionary } from "./schema.props";
 import { getNavigationDictionary } from "./navigation";
+import { removeRootDataNodeErrorMessage } from "./errors";
 
 describe("getMessage", () => {
     describe("history", () => {
@@ -1023,6 +1024,132 @@ describe("getMessage", () => {
                 "data",
             ]);
             expect(message[0].linkedDataIds).to.deep.equal(["data2", "data3"]);
+        });
+        it("should remove the active dictionary ID as linked data if linked data is not supplied and if the active dictionary ID is not the root dictionary ID", () => {
+            getMessage([
+                {
+                    type: MessageSystemType.initialize,
+                    dictionaryId: "data2",
+                    data: [
+                        {
+                            data: {
+                                schemaId: "foo",
+                                data: {
+                                    linkedData: [
+                                        {
+                                            id: "data2",
+                                        },
+                                    ],
+                                },
+                            },
+                            data2: {
+                                parent: {
+                                    dataLocation: "linkedData",
+                                    id: "data",
+                                },
+                                schemaId: "foo",
+                                data: {
+                                    hello: "world",
+                                    linkedData: [
+                                        {
+                                            id: "data3",
+                                        },
+                                    ],
+                                },
+                            },
+                            data3: {
+                                parent: {
+                                    dataLocation: "linkedData",
+                                    id: "data2",
+                                },
+                                schemaId: "foo",
+                                data: {
+                                    foo: "bar",
+                                },
+                            },
+                        },
+                        "data",
+                    ],
+                    schemaDictionary: {
+                        foo: {
+                            id: "foo",
+                            type: "object",
+                            properties: {
+                                linkedData: linkedDataSchema,
+                            },
+                        },
+                    },
+                },
+                "",
+            ]);
+            const message: InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing> = getMessage(
+                [
+                    {
+                        type: MessageSystemType.data,
+                        action: MessageSystemDataTypeAction.removeLinkedData,
+                    },
+                    "",
+                ]
+            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+
+            expect((message[0].data as any).linkedData).to.deep.equal([]);
+            expect(message[0].dataDictionary).to.deep.equal([
+                {
+                    data: {
+                        schemaId: "foo",
+                        data: {
+                            linkedData: [],
+                        },
+                    },
+                },
+                "data",
+            ]);
+            expect(message[0].linkedDataIds).to.deep.equal(["data2", "data3"]);
+        });
+        it("should send an error if the active dictionary ID is the root dictionary ID, linked data has not been supplied, and a different dictionary ID has not been specified", () => {
+            getMessage([
+                {
+                    type: MessageSystemType.initialize,
+                    data: [
+                        {
+                            data: {
+                                schemaId: "foo",
+                                data: {
+                                    linkedData: [
+                                        {
+                                            id: "data2",
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                        "data",
+                    ],
+                    schemaDictionary: {
+                        foo: {
+                            id: "foo",
+                            type: "object",
+                            properties: {
+                                linkedData: linkedDataSchema,
+                            },
+                        },
+                    },
+                },
+                "",
+            ]);
+            const message: InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing> = getMessage(
+                [
+                    {
+                        type: MessageSystemType.data,
+                        action: MessageSystemDataTypeAction.removeLinkedData,
+                    },
+                    "",
+                ]
+            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+
+            expect(message[0].type).to.equal(MessageSystemType.error);
+            expect((message[0] as any).message).to.equal(removeRootDataNodeErrorMessage);
+            console.log("message", message);
         });
         it("should reorder linkedData in the exist array of linkedData items", () => {
             getMessage([

--- a/packages/fast-tooling/src/message-system/types.ts
+++ b/packages/fast-tooling/src/message-system/types.ts
@@ -2,6 +2,7 @@ export enum MessageSystemType {
     custom = "custom",
     data = "data",
     dataDictionary = "data-dictionary",
+    error = "error",
     history = "history",
     navigation = "navigation",
     navigationDictionary = "navigation-dictionary",


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change allows the remove linked data action to default to removing the active dictionary ID. This provides an easy way for shortcuts to act on a "delete" option.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Related to #24

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Add a PR for shortcuts to execute using this updated API with an exported delete shortcuts action (see #153)