### PR TITLE
Update shortcut actions so they can directly assign the event listener to a provided HTML element

### DIFF
--- a/change/@microsoft-fast-tooling-cf84dc25-4bb5-4047-9dfc-c5ab3db7a0e2.json
+++ b/change/@microsoft-fast-tooling-cf84dc25-4bb5-4047-9dfc-c5ab3db7a0e2.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Update shortcut actions so they can directly assign the event listener to a provided HTML element and export an alpha shortcut action for deleting an active dictionary ID",
+  "comment": "Updated shortcut service which now directly assigns the event listener to a provided HTML element and export an alpha release shortcut action for deleting an active dictionary ID",
   "packageName": "@microsoft/fast-tooling",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-tooling-cf84dc25-4bb5-4047-9dfc-c5ab3db7a0e2.json
+++ b/change/@microsoft-fast-tooling-cf84dc25-4bb5-4047-9dfc-c5ab3db7a0e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update shortcut actions so they can directly assign the event listener to a provided HTML element and export an alpha shortcut action for deleting an active dictionary ID",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/app/examples/shortcuts/index.ts
+++ b/packages/fast-tooling/app/examples/shortcuts/index.ts
@@ -1,7 +1,8 @@
 import {
     MessageSystem,
-    MessageSystemDataTypeAction,
     MessageSystemType,
+    MessageSystemNavigationDictionaryTypeAction,
+    ShortcutsActionDelete,
 } from "../../../src";
 import {
     Shortcuts,
@@ -34,9 +35,7 @@ function handleMessageSystem(e: MessageEvent) {
         }
 
         if (e.data.type === MessageSystemType.initialize) {
-            const config: any = fastMessageSystem.getConfigById(shortcutsId) as any;
             inputElement.removeAttribute("disabled");
-            inputElement.addEventListener(config.eventListenerType, config.eventListener);
         }
     }
 }
@@ -50,36 +49,15 @@ if ((window as any).Worker) {
     fastMessageSystem.add({
         onMessage: handleMessageSystem,
     });
+    fastMessageSystem.postMessage({
+        type: MessageSystemType.navigationDictionary,
+        action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
+        activeDictionaryId: "text",
+    });
 
     fastShortcuts = new Shortcuts({
         messageSystem: fastMessageSystem,
-        actions: [
-            new ShortcutsAction({
-                id: "foo",
-                name: "Foo",
-                keys: [
-                    {
-                        ctrlKey: true,
-                    },
-                    {
-                        shiftKey: true,
-                    },
-                    {
-                        value: "D",
-                    },
-                ],
-                action: () => {
-                    fastMessageSystem.postMessage({
-                        type: MessageSystemType.data,
-                        action: MessageSystemDataTypeAction.removeLinkedData,
-                        dataLocation: "text",
-                        linkedData: [{ id: "text" }],
-                        options: {
-                            originatorId: shortcutsId,
-                        },
-                    });
-                },
-            }),
-        ],
+        target: inputElement,
+        actions: [ShortcutsActionDelete(fastMessageSystem)],
     });
 }

--- a/packages/fast-tooling/src/message-system-service/index.ts
+++ b/packages/fast-tooling/src/message-system-service/index.ts
@@ -1,3 +1,4 @@
 export * from "./ajv-validation.service";
 export * from "./monaco-adapter.service";
 export * from "./shortcuts.service";
+export * from "./shortcuts-service-actions";

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/__test__/data-dictionary.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/__test__/data-dictionary.ts
@@ -1,0 +1,41 @@
+import { DataDictionary } from "../../../message-system/data.props";
+
+export default [
+    {
+        root: {
+            schemaId: "div",
+            data: {
+                foo: "foobar",
+                bar: true,
+                Slot: [
+                    {
+                        id: "span",
+                    },
+                ],
+            },
+        },
+        span: {
+            parent: {
+                id: "root",
+                dataLocation: "Slot",
+            },
+            schemaId: "span",
+            data: {
+                Slot: [
+                    {
+                        id: "text",
+                    },
+                ],
+            },
+        },
+        text: {
+            parent: {
+                id: "span",
+                dataLocation: "Slot",
+            },
+            schemaId: "text",
+            data: "FooBar",
+        },
+    },
+    "root",
+] as DataDictionary<unknown>;

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/__test__/schema-dictionary.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/__test__/schema-dictionary.ts
@@ -1,0 +1,42 @@
+import { linkedDataSchema } from "../../../";
+import { ReservedElementMappingKeyword } from "../../../data-utilities/types";
+
+export default {
+    div: {
+        $id: "div",
+        id: "div",
+        type: "object",
+        [ReservedElementMappingKeyword.mapsToTagName]: "div",
+        properties: {
+            foo: {
+                title: "Foo",
+                type: "string",
+            },
+            bar: {
+                title: "Bar",
+                type: "boolean",
+            },
+            Slot: {
+                [ReservedElementMappingKeyword.mapsToSlot]: "",
+                ...linkedDataSchema,
+            },
+        },
+    },
+    span: {
+        $id: "span",
+        id: "span",
+        type: "object",
+        [ReservedElementMappingKeyword.mapsToTagName]: "span",
+        properties: {
+            Slot: {
+                [ReservedElementMappingKeyword.mapsToSlot]: "",
+                ...linkedDataSchema,
+            },
+        },
+    },
+    text: {
+        $id: "text",
+        id: "text",
+        type: "string",
+    },
+};

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/index.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/index.ts
@@ -1,0 +1,3 @@
+import ShortcutsActionDelete from "./shortcuts.service-action.delete";
+
+export { ShortcutsActionDelete };

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
@@ -1,0 +1,68 @@
+import chai, { expect } from "chai";
+import spies from "chai-spies";
+import { Register } from "../../message-system/message-system.props";
+import MessageSystem from "../../message-system/message-system";
+import {
+    MessageSystemDataTypeAction,
+    MessageSystemNavigationDictionaryTypeAction,
+} from "../../message-system/message-system.utilities.props";
+import { MessageSystemType } from "../../message-system/types";
+import { Shortcuts } from "../shortcuts.service";
+import { ShortcutsAction } from "../shortcuts.service-action";
+import ShortcutsActionDelete from "./shortcuts.service-action.delete";
+import dataDictionary from "./__test__/data-dictionary";
+import schemaDictionary from "./__test__/schema-dictionary";
+
+chai.use(spies);
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+describe("ShortcutsActionDelete", () => {
+    it("should return an instance of a ShortcutAction", () => {
+        expect(
+            ShortcutsActionDelete(new MessageSystem({ webWorker: "" })) instanceof
+                ShortcutsAction
+        ).to.be.true;
+    });
+    it("should call an event to delete the active dictionary ID item when the keyboard event is used", () => {
+        const inputElement = document.createElement("input");
+        let callbackArgs = null;
+        const postMessageCallback: any = chai.spy((config: any) => {
+            callbackArgs = config;
+        });
+
+        const messageSystem = new MessageSystem({
+            webWorker: "",
+            dataDictionary,
+            schemaDictionary,
+        });
+        messageSystem.postMessage = postMessageCallback;
+        messageSystem["register"].forEach((registeredItem: Register) => {
+            registeredItem.onMessage({
+                data: {
+                    type: MessageSystemType.navigationDictionary,
+                    action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
+                    activeDictionaryId: "text",
+                },
+            } as any);
+        });
+
+        new Shortcuts({
+            messageSystem: messageSystem,
+            target: inputElement,
+            actions: [ShortcutsActionDelete(messageSystem)],
+        });
+
+        expect(postMessageCallback).to.have.been.called.exactly(0);
+
+        const keyboardEvent = new KeyboardEvent("keydown", {
+            key: "Delete",
+        });
+        inputElement.dispatchEvent(keyboardEvent);
+
+        expect(postMessageCallback).to.have.been.called.exactly(1);
+        expect(callbackArgs.type).to.equal(MessageSystemType.data);
+        expect(callbackArgs.action).to.equal(
+            MessageSystemDataTypeAction.removeLinkedData
+        );
+    });
+});

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
@@ -15,13 +15,20 @@ import schemaDictionary from "./__test__/schema-dictionary";
 
 chai.use(spies);
 
+/**
+ * These tests rely on some async functionality.
+ * They are therefore not included with the rest of the coverage
+ * and should be run only locally when making changes to the MonacoAdapter service.
+ *
+ * TODO: enable these tests #4602
+ */
 /* eslint-disable @typescript-eslint/no-empty-function */
-describe("ShortcutsActionDelete", () => {
+xdescribe("ShortcutsActionDelete", () => {
     it("should return an instance of a ShortcutAction", () => {
         expect(
             ShortcutsActionDelete(new MessageSystem({ webWorker: "" })) instanceof
                 ShortcutsAction
-        ).to.be.true;
+        ).to.equal(true);
     });
     it("should call an event to delete the active dictionary ID item when the keyboard event is used", () => {
         const inputElement = document.createElement("input");

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.ts
@@ -1,0 +1,39 @@
+import { ShortcutsAction } from "../shortcuts.service-action";
+import {
+    MessageSystem,
+    MessageSystemDataTypeAction,
+    MessageSystemType,
+} from "../../message-system";
+import { shortcutsId } from "../shortcuts.service";
+
+/**
+ * @alpha
+ */
+export default function ShortcutsActionDelete(
+    messageSystem: MessageSystem
+): ShortcutsAction {
+    return new ShortcutsAction({
+        id: "delete",
+        name: "Delete",
+        keys: [
+            {
+                ctrlKey: true,
+            },
+            {
+                shiftKey: true,
+            },
+            {
+                value: "D",
+            },
+        ],
+        action: () => {
+            messageSystem.postMessage({
+                type: MessageSystemType.data,
+                action: MessageSystemDataTypeAction.removeLinkedData,
+                options: {
+                    originatorId: shortcutsId,
+                },
+            });
+        },
+    });
+}

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.ts
@@ -17,13 +17,7 @@ export default function ShortcutsActionDelete(
         name: "Delete",
         keys: [
             {
-                ctrlKey: true,
-            },
-            {
-                shiftKey: true,
-            },
-            {
-                value: "D",
+                value: "Delete",
             },
         ],
         action: () => {

--- a/packages/fast-tooling/src/message-system-service/shortcuts.service-action.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts.service-action.ts
@@ -52,8 +52,8 @@ export type ShortcutsActionCallbackConfig = XOR<
 export function mapKeyboardEventToKeyConfig(e: KeyboardEvent): KeyConfig[] {
     const keys: KeyConfig[] = [];
 
-    // all keys larger than 1 are special keys
-    if (typeof e.key === "string" && e.key.length === 1) {
+    // all keys larger than length 1 are special keys
+    if (typeof e.key === "string") {
         keys.push({
             value: e.key,
         });

--- a/packages/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
@@ -35,6 +35,7 @@ xdescribe("Shortcuts", () => {
 
             new Shortcuts({
                 messageSystem,
+                target: document.body,
             });
         }).not.to.throw();
     });
@@ -42,6 +43,7 @@ xdescribe("Shortcuts", () => {
         expect(() => {
             new Shortcuts({
                 messageSystem: undefined,
+                target: document.body,
             });
         }).not.to.throw();
     });
@@ -66,6 +68,7 @@ xdescribe("Shortcuts", () => {
 
         new Shortcuts({
             messageSystem,
+            target: document.body,
         });
 
         expect(messageSystem["register"].size).to.equal(1);
@@ -91,6 +94,7 @@ xdescribe("Shortcuts", () => {
 
         const shortcuts: Shortcuts = new Shortcuts({
             messageSystem,
+            target: document.body,
         });
 
         expect(messageSystem["register"].size).to.equal(1);
@@ -132,6 +136,7 @@ xdescribe("Shortcuts", () => {
         const shortcuts = new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
 
         expect(shortcuts["registeredActions"]).to.equal(actions);
@@ -163,6 +168,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -201,6 +207,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -238,6 +245,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -275,6 +283,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -312,6 +321,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -349,6 +359,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -386,6 +397,7 @@ xdescribe("Shortcuts", () => {
         new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
@@ -433,6 +445,7 @@ xdescribe("Shortcuts", () => {
         const shortcuts = new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
         shortcuts.action("foo").run();
         expect(shortcutAction).to.have.been.called.exactly(1);
@@ -471,6 +484,7 @@ xdescribe("Shortcuts", () => {
         const shortcuts = new Shortcuts({
             messageSystem,
             actions,
+            target: document.body,
         });
 
         expect(() => {

--- a/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
@@ -49,6 +49,11 @@ export interface ShortcutMessageOutgoing extends CustomMessage<{}, ShortcutOptio
  */
 export interface ShortcutsConfig {
     /**
+     * The HTML element to target for the event listener
+     */
+    target: HTMLElement;
+
+    /**
      * The shortcut event listener used to attach to a DOM node
      */
     eventListener: (e: KeyboardEvent) => void;
@@ -69,6 +74,14 @@ export interface ShortcutsRegisterConfig {
 }
 
 /**
+ * @alpha
+ */
+export interface ShortcutsMessageSystemServiceConfig
+    extends MessageSystemServiceConfig<ShortcutsActionCallbackConfig, ShortcutsConfig> {
+    target: HTMLElement;
+}
+
+/**
  *
  * @alpha
  * @remarks
@@ -78,19 +91,20 @@ export class Shortcuts extends MessageSystemService<
     ShortcutsActionCallbackConfig,
     ShortcutsConfig
 > {
-    constructor(
-        config: MessageSystemServiceConfig<ShortcutsActionCallbackConfig, ShortcutsConfig>
-    ) {
+    constructor(config: ShortcutsMessageSystemServiceConfig) {
         super();
 
         this.registerMessageSystem({
             ...config,
             id: shortcutsId,
             config: {
+                target: config.target,
                 eventListener: this.listener,
                 eventListenerType: "keypress",
             },
         });
+
+        config.target.addEventListener("keypress", this.listener);
     }
 
     /**

--- a/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
@@ -9,7 +9,7 @@ import {
 } from "./message-system.service";
 
 export type shortcutsMessageSystemAction = "initialize";
-export type shortcutsMessageSystemListenerType = "keypress";
+export type shortcutsMessageSystemListenerType = "keydown";
 export type shortcutsMessageId = "fast-tooling::shortcuts-service";
 
 /**
@@ -100,11 +100,11 @@ export class Shortcuts extends MessageSystemService<
             config: {
                 target: config.target,
                 eventListener: this.listener,
-                eventListenerType: "keypress",
+                eventListenerType: "keydown",
             },
         });
 
-        config.target.addEventListener("keypress", this.listener);
+        config.target.addEventListener("keydown", this.listener);
     }
 
     /**

--- a/packages/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.ts
@@ -33,7 +33,6 @@ import {
     NavigationDictionaryMessageOutgoing,
     NavigationMessageIncoming,
     NavigationMessageOutgoing,
-    RemoveLinkedDataDataMessageIncoming,
     SchemaDictionaryMessageIncoming,
     SchemaDictionaryMessageOutgoing,
     ValidationMessageIncoming,


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change does the following:
- Update shortcut actions so they can directly assign the event listener to a provided HTML element
- Add an export for the delete shortcut action

Relies on the completion of #152 to pass the build.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Resolves #24

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.