### PR TITLE
Updating component CSS class names and attributes to comply with style guide

### DIFF
--- a/change/@microsoft-fast-tooling-30f75b00-de1d-4318-9ba5-baca13459acb.json
+++ b/change/@microsoft-fast-tooling-30f75b00-de1d-4318-9ba5-baca13459acb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated component CSS and Attributes to comply with style guide",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/color-picker/color-picker.spec.pw.ts
+++ b/packages/fast-tooling/src/web-components/color-picker/color-picker.spec.pw.ts
@@ -15,7 +15,7 @@ test.describe("Color Picker", () => {
 
     test("should open when clicked", async ({ page }) => {
         await page.click('#control input[type="text"]');
-        const colorUI = page.locator(".color-ui");
+        const colorUI = page.locator(".popup__open");
         await expect(colorUI).not.toBeNull();
         // Couldn't get the .isVisible() test to work so looking directly at the css.
         await expect(colorUI).toHaveCSS("display", "flex");
@@ -29,47 +29,47 @@ test.describe("Color Picker", () => {
         await expect(page.locator("#outputValue")).toHaveValue("#AABBCC");
 
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(1) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(1) input[type="text"]')
         ).toHaveValue("170");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(2) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(2) input[type="text"]')
         ).toHaveValue("187");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(3) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(3) input[type="text"]')
         ).toHaveValue("204");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(4) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(4) input[type="text"]')
         ).toHaveValue("210");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(5) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(5) input[type="text"]')
         ).toHaveValue("17");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(6) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(6) input[type="text"]')
         ).toHaveValue("80");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(7) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(7) input[type="text"]')
         ).toHaveValue("100");
         await page.fill('#control input[type="text"]', "rgba(64,128,127,0.5)");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(1) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(1) input[type="text"]')
         ).toHaveValue("64");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(2) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(2) input[type="text"]')
         ).toHaveValue("128");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(3) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(3) input[type="text"]')
         ).toHaveValue("127");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(4) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(4) input[type="text"]')
         ).toHaveValue("179");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(5) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(5) input[type="text"]')
         ).toHaveValue("50");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(6) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(6) input[type="text"]')
         ).toHaveValue("50");
         await expect(
-            page.locator('.color-ui fast-text-field:nth-child(7) input[type="text"]')
+            page.locator('.popup__open fast-text-field:nth-child(7) input[type="text"]')
         ).toHaveValue("50");
     });
 
@@ -77,33 +77,33 @@ test.describe("Color Picker", () => {
         await expect(page.locator('#control input[type="text"]')).toHaveValue("");
         await page.click('#control input[type="text"]');
         await page.fill(
-            '.color-ui fast-text-field:nth-child(1) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(1) input[type="text"]',
             "170"
         );
         await page.fill(
-            '.color-ui fast-text-field:nth-child(2) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(2) input[type="text"]',
             "187"
         );
         await page.fill(
-            '.color-ui fast-text-field:nth-child(3) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(3) input[type="text"]',
             "204"
         );
         await expect(page.locator('#control input[type="text"]')).toHaveValue("#aabbcc");
         await expect(page.locator("#outputValue")).toHaveValue("#aabbcc");
         await page.fill(
-            '.color-ui fast-text-field:nth-child(4) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(4) input[type="text"]',
             "179"
         );
         await page.fill(
-            '.color-ui fast-text-field:nth-child(5) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(5) input[type="text"]',
             "50"
         );
         await page.fill(
-            '.color-ui fast-text-field:nth-child(6) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(6) input[type="text"]',
             "50"
         );
         await page.fill(
-            '.color-ui fast-text-field:nth-child(7) input[type="text"]',
+            '.popup__open fast-text-field:nth-child(7) input[type="text"]',
             "50"
         );
         await expect(page.locator('#control input[type="text"]')).toHaveValue(
@@ -115,15 +115,15 @@ test.describe("Color Picker", () => {
     test("clicking pickers should change value", async ({ page }) => {
         await expect(page.locator('#control input[type="text"]')).toHaveValue("");
         await page.click('#control input[type="text"]');
-        await page.click(".sat-light-picker");
+        await page.click(".pickers-saturation");
         await expect(page.locator('#control input[type="text"]')).toHaveValue("#804040");
         await expect(page.locator("#outputValue")).toHaveValue("#804040");
 
-        await page.click(".hue-picker");
+        await page.click(".pickers-hue");
         await expect(page.locator('#control input[type="text"]')).toHaveValue("#40807f");
         await expect(page.locator("#outputValue")).toHaveValue("#40807f");
 
-        await page.click(".alpha-mask");
+        await page.click(".pickers-alpha");
         await expect(page.locator('#control input[type="text"]')).toHaveValue(
             "rgba(64,128,127,0.5)"
         );
@@ -133,7 +133,7 @@ test.describe("Color Picker", () => {
     test("dragging sliders should change value", async ({ page }) => {
         await expect(page.locator('#control input[type="text"]')).toHaveValue("");
         await page.click('#control input[type="text"]');
-        await page.click(".sat-light-picker");
+        await page.click(".pickers-saturation");
         await expect(page.locator('#control input[type="text"]')).toHaveValue("#804040");
         await page.mouse.move(142, 212);
         await page.mouse.down();

--- a/packages/fast-tooling/src/web-components/color-picker/color-picker.spec.ts
+++ b/packages/fast-tooling/src/web-components/color-picker/color-picker.spec.ts
@@ -109,7 +109,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[0];
 
         textField.dispatchEvent(event);
@@ -138,7 +138,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[1];
 
         textField.dispatchEvent(event);
@@ -167,7 +167,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[2];
 
         textField.dispatchEvent(event);
@@ -196,7 +196,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[3];
 
         textField.dispatchEvent(event);
@@ -225,7 +225,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[4];
 
         textField.dispatchEvent(event);
@@ -254,7 +254,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[5];
 
         textField.dispatchEvent(event);
@@ -283,7 +283,7 @@ describe("ColorPicker", () => {
         });
 
         const textField = element.shadowRoot?.querySelectorAll(
-            ".input-region fast-text-field"
+            ".inputs fast-text-field"
         )[6];
 
         textField.dispatchEvent(event);
@@ -306,7 +306,7 @@ describe("ColorPicker", () => {
             wasChanged = true;
         });
 
-        const satLightPicker = element.shadowRoot?.querySelector(".sat-light-picker");
+        const satLightPicker = element.shadowRoot?.querySelector(".pickers-saturation");
 
         satLightPicker.dispatchEvent(event);
 
@@ -328,7 +328,7 @@ describe("ColorPicker", () => {
             wasChanged = true;
         });
 
-        const huePicker = element.shadowRoot?.querySelector(".hue-picker");
+        const huePicker = element.shadowRoot?.querySelector(".pickers-hue");
 
         huePicker.dispatchEvent(event);
 
@@ -350,7 +350,7 @@ describe("ColorPicker", () => {
             wasChanged = true;
         });
 
-        const alphaPicker = element.shadowRoot?.querySelector(".alpha-picker");
+        const alphaPicker = element.shadowRoot?.querySelector(".pickers-alpha");
 
         alphaPicker.dispatchEvent(event);
 

--- a/packages/fast-tooling/src/web-components/color-picker/color-picker.styles.ts
+++ b/packages/fast-tooling/src/web-components/color-picker/color-picker.styles.ts
@@ -8,7 +8,8 @@ export const colorPickerStyles: (
     context: ElementDefinitionContext,
     definition: FoundationElementDefinition
 ) => ElementStyles = () => css`
-    .root .color-ui {
+    .popup,
+    .popup__open {
         display: none;
         padding: 2px;
         flex-direction: row;
@@ -17,23 +18,23 @@ export const colorPickerStyles: (
         border-radius: calc(var(--corner-radius) * 1px);
     }
 
-    .root.open .color-ui {
+    .popup__open {
         display: flex;
         position: absolute;
         z-index: 1;
         margin-left: -32px;
     }
 
-    .picker-region {
+    .pickers {
         margin: 4px 6px 4px 4px;
     }
 
-    .input-region {
+    .inputs {
         width: 65px;
         margin: 0 4px 4px 0;
     }
 
-    .sat-light-picker {
+    .pickers-saturation {
         position: relative;
         width: 200px;
         height: 200px;
@@ -44,7 +45,7 @@ export const colorPickerStyles: (
         border: 1px solid #fff;
     }
 
-    .sat-light-indicator {
+    .saturation-indicator {
         position: absolute;
         top: 0;
         left: 0;
@@ -55,7 +56,7 @@ export const colorPickerStyles: (
         pointer-events: none;
     }
 
-    .hue-picker {
+    .pickers-hue {
         position: relative;
         width: 200px;
         height: 30px;
@@ -85,7 +86,7 @@ export const colorPickerStyles: (
         margin-left: 1px;
     }
 
-    .alpha-picker {
+    .pickers-alpha {
         position: relative;
         width: 200px;
         height: 30px;
@@ -106,7 +107,7 @@ export const colorPickerStyles: (
         margin-bottom: 5px;
     }
 
-    .selected-color {
+    .control-color {
         position: relative;
         display: inline-block;
         width: 25px;
@@ -116,7 +117,7 @@ export const colorPickerStyles: (
         border: 1px solid var(--fast-tooling-l1-color, #333333);
     }
 
-    .selected-color::before {
+    .control-color::before {
         position: absolute;
         content: "";
         left: 0;
@@ -131,7 +132,7 @@ export const colorPickerStyles: (
         );
     }
 
-    .selected-color::after {
+    .control-color::after {
         position: absolute;
         content: "";
         left: 0;

--- a/packages/fast-tooling/src/web-components/color-picker/color-picker.template.ts
+++ b/packages/fast-tooling/src/web-components/color-picker/color-picker.template.ts
@@ -20,9 +20,9 @@ export const colorPickerTemplate: (
                 x.mouseActive ? x.handleMouseUp(c.event as MouseEvent) : null}"
             style="--selected-color-value: ${x => (x.value ? x.value : "transparent")}"
         >
-            <div class="root ${x => (x.open ? "open" : "")}" part="root">
+            <div class="root" part="root">
                 <${context.tagFor(TextField)}
-                    class="control"
+                    class="root-control"
                     part="control"
                     id="control"
                     @input="${x => x.handleTextInput()}"
@@ -35,25 +35,25 @@ export const colorPickerTemplate: (
                     :value="${x => x.value}"
                     ${ref("control")}
                 >
-                    <div slot="start" class="selected-color"></div>
+                    <div slot="start" class="control-color"></div>
                 </${context.tagFor(TextField)}>
-                <div class="color-ui">
-                    <div class="picker-region">
+                <div class="${x => (x.open ? "popup__open" : "popup")}">
+                    <div class="pickers">
                         <div
-                            class="sat-light-picker"
+                            class="pickers-saturation"
                             style="background-color:${x => x.uiValues.HueCSSColor}"
                             @mousedown="${(x, c) =>
                                 x.handleMouseDown("sv", c.event as MouseEvent)}"
                         >
                             <div
-                                class="sat-light-indicator"
+                                class="saturation-indicator"
                                 style="left: ${x =>
                                     x.uiValues.SatValLeftPos - 2}%; top: ${x =>
         x.uiValues.SatValTopPos - 2}%"
                             ></div>
                         </div>
                         <div
-                            class="hue-picker"
+                            class="pickers-hue"
                             @mousedown="${(x, c) =>
                                 x.handleMouseDown("h", c.event as MouseEvent)}"
                         >
@@ -63,7 +63,7 @@ export const colorPickerTemplate: (
                             ></div>
                         </div>
                         <div
-                            class="alpha-picker"
+                            class="pickers-alpha"
                             @mousedown="${(x, c) =>
                                 x.handleMouseDown("a", c.event as MouseEvent)}"
                         >
@@ -78,7 +78,7 @@ export const colorPickerTemplate: (
                             ></div>
                         </div>
                     </div>
-                    <div class="input-region">
+                    <div class="inputs">
                         <${context.tagFor(TextField)}
                             maxlength="3"
                             size="3"

--- a/packages/fast-tooling/src/web-components/css-box-model/css-box-model.style.ts
+++ b/packages/fast-tooling/src/web-components/css-box-model/css-box-model.style.ts
@@ -14,11 +14,11 @@ export const cssBoxModelStyles = css`
         margin-bottom: 10px;
         white-space: nowrap;
     }
-    .section_label {
+    .section-label {
         display: inline-block;
         margin-bottom: 10px;
     }
-    .singleInput_hidden {
+    .singleInput__hidden {
         display: none;
     }
     .sideButton {
@@ -27,7 +27,7 @@ export const cssBoxModelStyles = css`
     .sideButton path {
         fill: ${neutralForegroundRest};
     }
-    .sideButton_active {
+    .sideButton__active {
         background-color: ${neutralFillStealthActive};
     }
     .grid {
@@ -38,7 +38,7 @@ export const cssBoxModelStyles = css`
     .grid-dimension {
         grid-template-columns: 50% 50%;
     }
-    .grid_hidden {
+    .grid__hidden {
         display: none;
     }
     .item {

--- a/packages/fast-tooling/src/web-components/css-box-model/css-box-model.template.ts
+++ b/packages/fast-tooling/src/web-components/css-box-model/css-box-model.template.ts
@@ -26,11 +26,11 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
 >`
     <template>
         <div class="section">
-            <label for="margin" class="section_label">Margin</label>
+            <label for="margin" class="section-label">Margin</label>
             <br />
             <div
                 class="${x =>
-                    x.marginOpen ? "singleInput singleInput_hidden" : "singleInput"}"
+                    x.marginOpen ? "singleInput singleInput__hidden" : "singleInput"}"
             >
                 <fast-tooling-units-text-field
                     id="margin"
@@ -48,7 +48,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                     ${sidesButton}
                 </fast-button>
             </div>
-            <div class="${x => (x.marginOpen ? "grid" : "grid grid_hidden")}">
+            <div class="${x => (x.marginOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
                     <fast-tooling-units-text-field
                         id="margin-top"
@@ -101,10 +101,10 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
         </div>
         <br />
         <div class="section">
-            <label for="border" class="section_label">Border Width</label>
+            <label for="border" class="section-label">Border Width</label>
             <div
                 class="${x =>
-                    x.borderOpen ? "singleInput singleInput_hidden" : "singleInput"}"
+                    x.borderOpen ? "singleInput singleInput__hidden" : "singleInput"}"
             >
                 <fast-tooling-units-text-field
                     id="border"
@@ -122,7 +122,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                     ${sidesButton}
                 </fast-button>
             </div>
-            <div class="${x => (x.borderOpen ? "grid" : "grid grid_hidden")}">
+            <div class="${x => (x.borderOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
                     <fast-tooling-units-text-field
                         id="border-top-width"
@@ -136,7 +136,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 <div class="item item-topRight">
                     <fast-button
                         appearance="stealth"
-                        class="sideButton sideButton_active"
+                        class="sideButton sideButton__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.border)}"
                     >
@@ -177,10 +177,10 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
         </div>
         <br />
         <div class="section">
-            <label for="padding" class="section_label">Padding</label>
+            <label for="padding" class="section-label">Padding</label>
             <div
                 class="${x =>
-                    x.paddingOpen ? "singleInput singleInput_hidden" : "singleInput"}"
+                    x.paddingOpen ? "singleInput singleInput__hidden" : "singleInput"}"
             >
                 <fast-tooling-units-text-field
                     id="padding"
@@ -198,7 +198,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                     ${sidesButton}
                 </fast-button>
             </div>
-            <div class="${x => (x.paddingOpen ? "grid" : "grid grid_hidden")}">
+            <div class="${x => (x.paddingOpen ? "grid" : "grid grid__hidden")}">
                 <div class="item item-top">
                     <fast-tooling-units-text-field
                         id="padding-top"
@@ -211,7 +211,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 <div class="item item-topRight">
                     <fast-button
                         appearance="stealth"
-                        class="sideButton sideButton_active"
+                        class="sideButton sideButton__active"
                         @click="${(x, c) =>
                             x.handleOpenButtonClick(expandableSection.padding)}"
                     >
@@ -256,7 +256,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
             <div class="grid grid-dimension">
                 <div class="item">
                     <div class="dimension">
-                        <label for="width" class="section_label">Width</label>
+                        <label for="width" class="section-label">Width</label>
                         <br />
                         <fast-tooling-units-text-field
                             id="width"
@@ -269,7 +269,7 @@ export const cssBoxModelTemplate = (context: ElementDefinitionContext) => html<
                 </div>
                 <div class="item">
                     <div class="dimension">
-                        <label for="height" class="section_label">Height</label>
+                        <label for="height" class="section-label">Height</label>
                         <br />
                         <fast-tooling-units-text-field
                             id="height"

--- a/packages/fast-tooling/src/web-components/css-layout/css-layout.spec.ts
+++ b/packages/fast-tooling/src/web-components/css-layout/css-layout.spec.ts
@@ -20,9 +20,9 @@ describe("CSSLayout", () => {
 
         await connect();
 
-        const controlRegion = element.shadowRoot?.querySelector(".flexbox-controls");
+        const controlRegion = element.shadowRoot?.querySelector(".flexboxRegion");
 
-        expect(controlRegion.classList.contains("active")).to.equal(false);
+        expect(controlRegion).to.not.be.null;
 
         await disconnect();
     });
@@ -36,11 +36,11 @@ describe("CSSLayout", () => {
 
         toggle.dispatchEvent(toggleEvent);
 
-        const controlRegion = element.shadowRoot?.querySelector(".flexbox-controls");
-
         await DOM.nextUpdate();
 
-        expect(controlRegion.classList.contains("active")).to.equal(true);
+        const controlRegion = element.shadowRoot?.querySelector(".flexboxRegion__active");
+
+        expect(controlRegion).to.not.be.null;
 
         await disconnect();
     });
@@ -295,7 +295,7 @@ describe("CSSLayout", () => {
         await DOM.nextUpdate();
 
         const rowGapInput = element.shadowRoot?.querySelector(
-            "input.css-row-gap"
+            "#fast-tooling-css-row-gap"
         ) as HTMLInputElement;
         rowGapInput.value = "5";
 
@@ -329,7 +329,7 @@ describe("CSSLayout", () => {
         await DOM.nextUpdate();
 
         const columnGapInput = element.shadowRoot?.querySelector(
-            "input.css-column-gap"
+            "#fast-tooling-css-column-gap"
         ) as HTMLInputElement;
         columnGapInput.value = "5";
 

--- a/packages/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
+++ b/packages/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
@@ -75,7 +75,7 @@ export const cssLayoutStyles = css`
         column-gap: 2px;
     }
 
-    .radioRegion-div {
+    .radioRegion-contentItem {
         background: ${radioBackgroundColor};
         border-radius: ${borderRadius};
         border: 3px solid #1b1b1b;
@@ -84,7 +84,7 @@ export const cssLayoutStyles = css`
         max-width: 24px;
     }
 
-    .radioRegion-div__active {
+    .radioRegion-contentItem__active {
         background: ${activeRadioBackgroundColor};
         border-color: ${activeRadioBorderColor};
     }

--- a/packages/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
+++ b/packages/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
@@ -20,42 +20,39 @@ export const cssLayoutStyles = css`
         margin: 10px 0 5px;
     }
 
-    .flexbox-controls {
+    .flexboxRegion {
         display: none;
     }
 
-    .flexbox-controls.active {
+    .flexboxRegion__active {
         display: block;
     }
 
-    .control-region {
+    .controlRegion,
+    .controlRegion-row {
         display: flex;
         flex-direction: column;
     }
 
-    .control-region.row {
+    .controlRegion-row {
         flex-direction: row;
     }
 
-    .css-row-gap,
-    .css-column-gap {
-        vertical-align: middle;
-    }
-
-    .control-numberfield-region {
+    .numberfield {
         display: flex;
         column-gap: 12px;
     }
 
-    .control-numberfield-region .icon {
+    .numberfield-icon {
         position: relative;
         padding: 5px;
         width: 12px;
         height: 12px;
     }
 
-    .control-numberfield-region input {
+    .numberfield-input {
         background: transparent;
+        vertical-align: middle;
         outline: none;
         border: none;
         width: 40px;
@@ -63,7 +60,7 @@ export const cssLayoutStyles = css`
         color: #fff;
     }
 
-    .control-numberfield-region input::-webkit-inner-spin-button {
+    .numberfield-input::-webkit-inner-spin-button {
         -webkit-appearance: none;
     }
 
@@ -73,12 +70,12 @@ export const cssLayoutStyles = css`
         border-radius: ${borderRadius};
     }
 
-    .control-radio-region {
+    .radioRegion {
         display: flex;
         column-gap: 2px;
     }
 
-    .control-radio-region > div {
+    .radioRegion-div {
         background: ${radioBackgroundColor};
         border-radius: ${borderRadius};
         border: 3px solid #1b1b1b;
@@ -87,12 +84,12 @@ export const cssLayoutStyles = css`
         max-width: 24px;
     }
 
-    .control-radio-region .active {
+    .radioRegion-div__active {
         background: ${activeRadioBackgroundColor};
         border-color: ${activeRadioBorderColor};
     }
 
-    .control-radio-region > div > input {
+    .radioRegion-input {
         width: 24px;
         height: 24px;
         margin: 0;

--- a/packages/fast-tooling/src/web-components/css-layout/css-layout.template.ts
+++ b/packages/fast-tooling/src/web-components/css-layout/css-layout.template.ts
@@ -549,10 +549,10 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         x => x.flexDirectionOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-div ${(x, c) =>
+                                class="radioRegion-contentItem ${(x, c) =>
                                     c.parent.flexDirectionName} ${x => x} ${(x, c) =>
                             x === c.parent.flexDirectionValue
-                                ? "radioRegion-div__active"
+                                ? "radioRegion-contentItem__active"
                                 : ""}"
                             >
                                 ${x =>
@@ -608,10 +608,10 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         x => x.justifyContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-div ${(x, c) =>
+                                class="radioRegion-contentItem ${(x, c) =>
                                     c.parent.justifyContentName} ${x => x} ${(x, c) =>
                             x === c.parent.justifyContentValue
-                                ? "radioRegion-div__active"
+                                ? "radioRegion-contentItem__active"
                                 : ""}"
                             >
                                 ${x =>
@@ -671,10 +671,10 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         x => x.alignContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-div ${(x, c) =>
+                                class="radioRegion-contentItem ${(x, c) =>
                                     c.parent.alignContentName} ${x => x} ${(x, c) =>
                             x === c.parent.alignContentValue
-                                ? "radioRegion-div__active"
+                                ? "radioRegion-contentItem__active"
                                 : ""}"
                             >
                                 ${x =>
@@ -736,10 +736,10 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         x => x.alignItemsOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-div ${(x, c) =>
+                                class="radioRegion-contentItem ${(x, c) =>
                                     c.parent.alignItemsName} ${x => x} ${(x, c) =>
                             x === c.parent.alignItemsValue
-                                ? "radioRegion-div__active"
+                                ? "radioRegion-contentItem__active"
                                 : ""}"
                             >
                                 ${x =>
@@ -826,10 +826,10 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         x => x.flexWrapOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="radioRegion-div ${(x, c) =>
+                                class="radioRegion-contentItem ${(x, c) =>
                                     c.parent.flexWrapName} ${x => x} ${(x, c) =>
                             x === c.parent.flexWrapValue
-                                ? "radioRegion-div__active"
+                                ? "radioRegion-contentItem__active"
                                 : ""}"
                             >
                                 ${x =>

--- a/packages/fast-tooling/src/web-components/css-layout/css-layout.template.ts
+++ b/packages/fast-tooling/src/web-components/css-layout/css-layout.template.ts
@@ -531,7 +531,7 @@ const columnGap = html`
  */
 export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSSLayout>`
     <template>
-        <div class="control-region">
+        <div class="controlRegion">
             <${context.tagFor(Switch)}
                 :checked="${x => x.flexEnabled}"
                 @keypress="${(x, c) =>
@@ -541,17 +541,19 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                 Enable Flexbox
             </${context.tagFor(Switch)}>
         </div>
-        <div class="flexbox-controls${x => (x.flexEnabled ? ` active` : "")}">
-            <div class="control-region">
+        <div class="${x => (x.flexEnabled ? `flexboxRegion__active` : "flexboxRegion")}">
+            <div class="controlRegion">
                 <label for="fast-tooling-css-flex-direction">Direction</label>
-                <div class="control-radio-region">
+                <div class="radioRegion">
                     ${repeat(
                         x => x.flexDirectionOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="${(x, c) => c.parent.flexDirectionName} ${x =>
-                            x} ${(x, c) =>
-                            x === c.parent.flexDirectionValue ? "active" : ""}"
+                                class="radioRegion-div ${(x, c) =>
+                                    c.parent.flexDirectionName} ${x => x} ${(x, c) =>
+                            x === c.parent.flexDirectionValue
+                                ? "radioRegion-div__active"
+                                : ""}"
                             >
                                 ${x =>
                                     x === "row"
@@ -568,6 +570,7 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
+                                    class="radioRegion-input"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.flexDirectionName}"
                                     value="${x => x}"
@@ -598,16 +601,18 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     )}
                 </div>
             </div>
-            <div class="control-region">
+            <div class="controlRegion">
                 <label for="fast-tooling-css-justify-content">Justify Content</label>
-                <div class="control-radio-region">
+                <div class="radioRegion">
                     ${repeat(
                         x => x.justifyContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="${(x, c) => c.parent.justifyContentName} ${x =>
-                            x} ${(x, c) =>
-                            x === c.parent.justifyContentValue ? "active" : ""}"
+                                class="radioRegion-div ${(x, c) =>
+                                    c.parent.justifyContentName} ${x => x} ${(x, c) =>
+                            x === c.parent.justifyContentValue
+                                ? "radioRegion-div__active"
+                                : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -628,6 +633,7 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
+                                    class="radioRegion-input"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.justifyContentName}"
                                     value="${x => x}"
@@ -658,16 +664,18 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     )}
                 </div>
             </div>
-            <div class="control-region">
+            <div class="controlRegion">
                 <label for="fast-tooling-css-align-content">Align Content</label>
-                <div class="control-radio-region">
+                <div class="radioRegion">
                     ${repeat(
                         x => x.alignContentOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="${(x, c) => c.parent.alignContentName} ${x =>
-                            x} ${(x, c) =>
-                            x === c.parent.alignContentValue ? "active" : ""}"
+                                class="radioRegion-div ${(x, c) =>
+                                    c.parent.alignContentName} ${x => x} ${(x, c) =>
+                            x === c.parent.alignContentValue
+                                ? "radioRegion-div__active"
+                                : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -690,6 +698,7 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             x
                                         )}"
                                     type="radio"
+                                    class="radioRegion-input"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.alignContentName}"
                                     value="${x => x}"
@@ -720,17 +729,18 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     )}
                 </div>
             </div>
-            <div class="control-region">
+            <div class="controlRegion">
                 <label for="fast-tooling-css-align-items">Align Items</label>
-                <div class="control-radio-region">
+                <div class="radioRegion">
                     ${repeat(
                         x => x.alignItemsOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="${(x, c) => c.parent.alignItemsName} ${x => x} ${(
-                            x,
-                            c
-                        ) => (x === c.parent.alignItemsValue ? "active" : "")}"
+                                class="radioRegion-div ${(x, c) =>
+                                    c.parent.alignItemsName} ${x => x} ${(x, c) =>
+                            x === c.parent.alignItemsValue
+                                ? "radioRegion-div__active"
+                                : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -744,6 +754,7 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                     id="${(x, c) =>
                                         c.parent.getInputId(c.parent.alignItemsName, x)}"
                                     type="radio"
+                                    class="radioRegion-input"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.alignItemsName}"
                                     value="${x => x}"
@@ -770,17 +781,17 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     )}
                 </div>
             </div>
-            <div class="control-region row">
-                <div class="control-numberfield-region">
+            <div class="controlRegion-row">
+                <div class="numberfield">
                     <div>
                         <label for="fast-tooling-css-row-gap">Row gap</label>
                         <div class="numberfield-item">
-                            <div class="icon">
+                            <div class="numberfield-icon">
                                 ${rowGap}
                             </div>
                             <input
                                 name="${x => x.rowGapName}"
-                                class="css-row-gap"
+                                class="numberfield-input"
                                 type="number"
                                 id="fast-tooling-css-row-gap"
                                 :value="${x => x.rowGapValue}"
@@ -792,12 +803,12 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     <div>
                         <label for="fast-tooling-css-column-gap">Column gap</label>
                         <div class="numberfield-item">
-                            <div class="icon">
+                            <div class="numberfield-icon">
                                 ${columnGap}
                             </div>
                             <input
                                 name="${x => x.columnGapName}"
-                                class="css-column-gap"
+                                class="numberfield-input"
                                 type="number"
                                 id="fast-tooling-css-column-gap"
                                 :value="${x => x.columnGapValue}"
@@ -808,17 +819,18 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                     </div>
                 </div>
             </div>
-            <div class="control-region">
+            <div class="controlRegion">
                 <label for="fast-tooling-css-flex-wrap">Wrap</label>
-                <div class="control-radio-region">
+                <div class="radioRegion">
                     ${repeat(
                         x => x.flexWrapOptions,
                         html<string, CSSLayout>`
                             <div
-                                class="${(x, c) => c.parent.flexWrapName} ${x => x} ${(
-                            x,
-                            c
-                        ) => (x === c.parent.flexWrapValue ? "active" : "")}"
+                                class="radioRegion-div ${(x, c) =>
+                                    c.parent.flexWrapName} ${x => x} ${(x, c) =>
+                            x === c.parent.flexWrapValue
+                                ? "radioRegion-div__active"
+                                : ""}"
                             >
                                 ${x =>
                                     x === "wrap"
@@ -830,6 +842,7 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                     id="${(x, c) =>
                                         c.parent.getInputId(c.parent.flexWrapName, x)}"
                                     type="radio"
+                                    class="radioRegion-input"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.flexWrapName}"
                                     value="${x => x}"

--- a/packages/fast-tooling/src/web-components/file/file.ts
+++ b/packages/fast-tooling/src/web-components/file/file.ts
@@ -39,8 +39,17 @@ export class File extends FormAssociatedFile {
      * Callback method for reporting progress of long running FileAction.
      * The progress value is calculated by the FileAction but should be a number between 0 and 1.
      */
-    @attr
+    @attr({ attribute: "progress-callback" })
     public progressCallback: (progress: number) => Promise<void>;
+
+    /**
+     * @deprecated
+     */
+    @attr({ attribute: "progressCallback" })
+    public progressCallbackDepricated: (progress: number) => Promise<void>;
+    private progressCallbackDepricatedChanged(): void {
+        this.progressCallback = this.progressCallbackDepricated;
+    }
 
     /**
      * After file(s) are selected this property will contain a string array with the references

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.style.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.style.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 
 export const htmlRenderLayerInlineEditStyles = css`
-    .edit-region {
+    .edit {
         position: fixed;
         top: 0;
         right: 0;
@@ -10,7 +10,8 @@ export const htmlRenderLayerInlineEditStyles = css`
         pointer-events: none;
     }
 
-    .text-area {
+    .edit-textArea,
+    .edit-textArea__active {
         display: none;
         position: absolute;
         box-sizing: content-box;
@@ -29,7 +30,7 @@ export const htmlRenderLayerInlineEditStyles = css`
         white-space: pre-wrap;
     }
 
-    .text-area.active {
+    .edit-textArea__active {
         display: block;
     }
 `;

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.template.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.template.ts
@@ -2,10 +2,10 @@ import { html, ref } from "@microsoft/fast-element";
 import { HTMLRenderLayerInlineEdit } from "./html-render-layer-inline-edit";
 
 export const htmlRenderLayerInlineEditTemplate = html<HTMLRenderLayerInlineEdit>`
-    <div class="edit-region">
+    <div class="edit">
         <textarea
             ${ref("textAreaRef")}
-            class="${x => (x.textAreaActive ? "text-area active" : "text-area")}"
+            class="${x => (x.textAreaActive ? "edit-textArea__active" : "edit-textArea")}"
             @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
             @keyup="${(x, c) => x.handleTextInput(c.event as KeyboardEvent)}"
             @click="${(x, c) => {

--- a/packages/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -29,8 +29,17 @@ export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
      * should be specific enough to return only one element, otherwise only the first match
      * will be used.
      */
+    @attr({ attribute: "resize-observer-selector" })
+    public resizeObserverSelector: string;
+
+    /**
+     * @deprecated
+     */
     @attr
     public resizeobserverselector: string;
+    private resizeobserverselectorChanged(): void {
+        this.resizeObserverSelector = this.resizeobserverselector;
+    }
 
     public layerActivityId: string = "NavLayer";
 
@@ -77,9 +86,9 @@ export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
         );
 
         this.resizeDetector.observe(
-            (this.resizeobserverselector
+            (this.resizeObserverSelector
                 ? (this.getRootNode() as Element).querySelector(
-                      this.resizeobserverselector
+                      this.resizeObserverSelector
                   )
                 : null) ?? document.body
         );

--- a/packages/fast-tooling/src/web-components/html-render/html-render.styles.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.styles.ts
@@ -1,19 +1,20 @@
 import { css } from "@microsoft/fast-element";
 
 export const htmlRenderStyles = (context, definition) => css`
-    .container {
+    .container,
+    .container__interactive {
         width: 100%;
         height: 100%;
         padding: 0;
         box-sizing: border-box;
     }
-    .html-render {
+    .htmlRender {
         width: 100%;
         height: 100%;
         outline: none;
         display: flow-root;
     }
-    .html-render > * {
+    .htmlRender > * {
         display: flow-root;
     }
 `;

--- a/packages/fast-tooling/src/web-components/html-render/html-render.template.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.template.ts
@@ -7,11 +7,11 @@ export const htmlRenderTemplate: (
 ) => ViewTemplate<HTMLRender> = context => {
     return html<HTMLRender>`
         <div
-            class="${x => (x.interactiveMode ? "container interactive" : "container")}"
+            class="${x => (x.interactiveMode ? "container__interactive" : "container")}"
             @click="${(x, c) => x.containerClickHandler(c.event as MouseEvent)}"
         >
             <div
-                class="html-render"
+                class="htmlRender"
                 @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
                 @dblclick="${(x, c) => x.dblClickHandler(c.event as MouseEvent)}"
                 @mouseover="${(x, c) => x.hoverHandler(c.event as MouseEvent)}"


### PR DESCRIPTION
# Pull Request

## 📖 Description
This updates the class names and attributes of the web components to comply with the style guide.

Once this PR is complete and Creator has been updated to use this version of fast-tooling then uses of the deprecated attribute names should be updated in Creator (https://github.com/microsoft/fast-creator/issues/121).


<!--- Provide some background and a description of your work. -->

### 🎫 Issues

Closes: #87 
<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->