### PR TITLE
Update history to use a previous and next property that will be triggered when moving through the stack

### DIFF
--- a/change/@microsoft-fast-tooling-af41f27c-c9ae-4850-913d-95d801e26f2d.json
+++ b/change/@microsoft-fast-tooling-af41f27c-c9ae-4850-913d-95d801e26f2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update history to use a previous and next property that will be triggered when moving through the stack",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/message-system/data.props.ts
+++ b/packages/fast-tooling/src/message-system/data.props.ts
@@ -85,6 +85,11 @@ export interface LinkedDataDictionaryConfig {
     linkedData: Data<unknown>[];
 
     /**
+     * The IDs to be used for the linked data
+     */
+    linkedDataIds: string[];
+
+    /**
      * The root dictionary ID
      */
     dictionaryId: string;
@@ -105,4 +110,19 @@ export interface LinkedDataDictionaryUpdate {
      * The dictionary ID to add the root of this data dictionary to
      */
     dictionaryId: string;
+}
+
+/**
+ * The removal of linked data can be done in 3 different ways:
+ *
+ * 1. If the dictionary ID is provided, this is the parent
+ * 2. If the dictionary ID is not provided, assume the active dictionary ID is the parent
+ * 3. If the dictionary ID is not provided and the linked data is not provided, assume the
+ *    active dictionary ID is the linked data to be removed and the parent is the active dictionary ID's parent
+ * 4. If in the case of 3. the active dictionary ID has no parent (is the root ID), send an error message
+ */
+export enum RemoveLinkedDataParentType {
+    activeDictionaryId,
+    activeDictionaryIdParent,
+    suppliedDictionaryId,
 }

--- a/packages/fast-tooling/src/message-system/data.spec.ts
+++ b/packages/fast-tooling/src/message-system/data.spec.ts
@@ -19,6 +19,7 @@ describe("getLinkedDataDictionary", () => {
                 },
             ],
             dictionaryId,
+            linkedDataIds: ["foo"],
             dataLocation: "root-location",
         });
         const linkedDataDictionaryKeys = Object.keys(
@@ -71,6 +72,7 @@ describe("getLinkedDataDictionary", () => {
                     linkedData: [nestedLinkedData],
                 },
             ],
+            linkedDataIds: ["foo", "bar", "bat", "baz"],
             dictionaryId,
             dataLocation: "root-location",
         });
@@ -113,6 +115,7 @@ describe("getLinkedDataDictionary", () => {
                     linkedData: [nestedNestedLinkedData1, nestedNestedLinkedData2],
                 },
             ],
+            linkedDataIds: ["foo", "bar"],
             dictionaryId,
             dataLocation: "root-location",
         });

--- a/packages/fast-tooling/src/message-system/data.ts
+++ b/packages/fast-tooling/src/message-system/data.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, uniqueId, unset } from "lodash-es";
+import { cloneDeep, get, unset } from "lodash-es";
 import {
     Data,
     DataDictionary,
@@ -7,17 +7,20 @@ import {
     LinkedDataDictionaryUpdate,
 } from "./data.props";
 
+let linkedDataItemIndex = 0;
+
 /**
  * Resolves a set of data dictionaries from multiple data items
  */
 function resolveDataDictionaries(
+    ids: string[],
     parentId: string,
     parentDataLocation: string,
     dataSet: Data<unknown>[]
 ): DataDictionary<unknown>[] {
     return dataSet.map(dataItem => {
         /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        return resolveDataDictionary(parentId, parentDataLocation, dataItem, {});
+        return resolveDataDictionary(ids, parentId, parentDataLocation, dataItem, {});
     });
 }
 
@@ -25,17 +28,19 @@ function resolveDataDictionaries(
  * Resolves a data dictionary from a data item
  */
 function resolveDataDictionary(
+    ids: string[],
     parentId: string,
     parentDataLocation: string,
     data: Data<unknown>,
     itemDictionary: { [key: string]: Data<unknown> }
 ): DataDictionary<unknown> {
-    const id: string = uniqueId("fast");
+    const id: string = ids[linkedDataItemIndex];
+    linkedDataItemIndex++;
     const dataDictionary: DataDictionary<unknown> = [itemDictionary, id];
     const linkedDataDictionary: DataDictionary<unknown>[] | null = Array.isArray(
         data.linkedData
     )
-        ? resolveDataDictionaries(id, parentDataLocation, data.linkedData)
+        ? resolveDataDictionaries(ids, id, parentDataLocation, data.linkedData)
         : null;
 
     const currentData = data.data;
@@ -79,7 +84,10 @@ function resolveDataDictionary(
 export function getLinkedDataDictionary(
     config: LinkedDataDictionaryConfig
 ): LinkedDataDictionaryUpdate {
+    linkedDataItemIndex = 0;
+
     const resolvedDataDictionary = resolveDataDictionaries(
+        config.linkedDataIds,
         config.dictionaryId,
         config.dataLocation,
         config.linkedData

--- a/packages/fast-tooling/src/message-system/history.props.ts
+++ b/packages/fast-tooling/src/message-system/history.props.ts
@@ -1,7 +1,8 @@
 import { MessageSystemIncoming } from "./message-system.utilities.props";
 
 export interface HistoryItem {
-    data: MessageSystemIncoming;
+    next: MessageSystemIncoming;
+    previous: MessageSystemIncoming;
     id: string;
 }
 

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -238,6 +238,8 @@ export interface GetNavigationDictionaryMessageOutgoing<TConfig = {}>
 
 /**
  * The message to update the active id of the data dictionary
+ * @deprecated - this should use the MessageSystemType.navigation
+ * action MessageSystemNavigationTypeAction.udpate
  */
 export interface UpdateActiveIdDataDictionaryMessageIncoming<TConfig = {}>
     extends ArbitraryMessageIncoming<TConfig> {
@@ -248,6 +250,8 @@ export interface UpdateActiveIdDataDictionaryMessageIncoming<TConfig = {}>
 
 /**
  * The message that the active id of the data dictionary has been updated
+ * @deprecated - this should use the MessageSystemType.navigation
+ * action MessageSystemNavigationTypeAction.udpate
  */
 export interface UpdateActiveIdDataDictionaryMessageOutgoing<TConfig = {}>
     extends ArbitraryMessageOutgoing<TConfig> {
@@ -257,6 +261,8 @@ export interface UpdateActiveIdDataDictionaryMessageOutgoing<TConfig = {}>
 
 /**
  * The message to update the active id of the navigation dictionary
+ * @deprecated - this should use the MessageSystemType.navigation
+ * action MessageSystemNavigationTypeAction.udpate
  */
 export interface UpdateActiveIdNavigationDictionaryMessageIncoming<TConfig = {}>
     extends ArbitraryMessageIncoming<TConfig> {
@@ -267,6 +273,8 @@ export interface UpdateActiveIdNavigationDictionaryMessageIncoming<TConfig = {}>
 
 /**
  * The message that the active id of the navigation dictionary has been updated
+ * @deprecated - this should use the MessageSystemType.navigation
+ * action MessageSystemNavigationTypeAction.udpate
  */
 export interface UpdateActiveIdNavigationDictionaryMessageOutgoing<TConfig = {}>
     extends ArbitraryMessageOutgoing<TConfig> {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This work is necessary foundational work for #158 where the undo and redo will be moving through the history stack.

This changes the history interface, so far unused, to include a `next` and `previous` properties which will trigger depending on the direction that history is moving in the stack.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Simplify some deprecated message system types #168 
- Create undo and redo shortcuts #158