### PR TITLE
Remove redundant message types

### DIFF
--- a/change/@microsoft-fast-tooling-c87c73ed-1448-4b0f-9312-b731466237e5.json
+++ b/change/@microsoft-fast-tooling-c87c73ed-1448-4b0f-9312-b731466237e5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove redundant message types",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
@@ -323,7 +323,7 @@ xdescribe("MonacoAdapter", () => {
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
                 data: {
-                    type: MessageSystemType.dataDictionary,
+                    type: MessageSystemType.data,
                     dataDictionary: dataDictionary2,
                     activeDictionaryId: "foo",
                 },

--- a/packages/fast-tooling/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/fast-tooling/src/message-system-service/monaco-adapter.service.ts
@@ -76,20 +76,18 @@ export class MonacoAdapter extends MessageSystemService<
                     });
                 }
                 break;
-            case MessageSystemType.dataDictionary:
-                this.dictionaryId = e.data.activeDictionaryId;
-                this.dataDictionary = e.data.dataDictionary;
-
-                break;
             case MessageSystemType.data:
+                this.dictionaryId = e.data.activeDictionaryId;
                 this.dataDictionary = e.data.dataDictionary;
 
                 break;
             case MessageSystemType.navigation:
                 this.dictionaryId = e.data.activeDictionaryId;
+
                 break;
             case MessageSystemType.schemaDictionary:
                 this.schemaDictionary = e.data.schemaDictionary;
+
                 break;
         }
     };

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.delete.spec.ts
@@ -4,7 +4,7 @@ import { Register } from "../../message-system/message-system.props";
 import MessageSystem from "../../message-system/message-system";
 import {
     MessageSystemDataTypeAction,
-    MessageSystemNavigationDictionaryTypeAction,
+    MessageSystemNavigationTypeAction,
 } from "../../message-system/message-system.utilities.props";
 import { MessageSystemType } from "../../message-system/types";
 import { Shortcuts } from "../shortcuts.service";
@@ -46,8 +46,8 @@ xdescribe("ShortcutsActionDelete", () => {
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
                 data: {
-                    type: MessageSystemType.navigationDictionary,
-                    action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
+                    type: MessageSystemType.navigation,
+                    action: MessageSystemNavigationTypeAction.update,
                     activeDictionaryId: "text",
                 },
             } as any);

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.ts
@@ -3,8 +3,7 @@ import spies from "chai-spies";
 import { Register } from "../../message-system/message-system.props";
 import MessageSystem from "../../message-system/message-system";
 import {
-    MessageSystemDataTypeAction,
-    MessageSystemNavigationDictionaryTypeAction,
+    MessageSystemDataTypeAction, MessageSystemNavigationTypeAction,
 } from "../../message-system/message-system.utilities.props";
 import { MessageSystemType } from "../../message-system/types";
 import { Shortcuts } from "../shortcuts.service";
@@ -53,8 +52,8 @@ xdescribe("ShortcutsActionDuplicate", () => {
         messageSystem["register"].forEach((registeredItem: Register) => {
             registeredItem.onMessage({
                 data: {
-                    type: MessageSystemType.navigationDictionary,
-                    action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
+                    type: MessageSystemType.navigation,
+                    action: MessageSystemNavigationTypeAction.update,
                     activeDictionaryId: "text",
                 },
             } as any);

--- a/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts-service-actions/shortcuts.service-action.duplicate.spec.ts
@@ -3,7 +3,8 @@ import spies from "chai-spies";
 import { Register } from "../../message-system/message-system.props";
 import MessageSystem from "../../message-system/message-system";
 import {
-    MessageSystemDataTypeAction, MessageSystemNavigationTypeAction,
+    MessageSystemDataTypeAction,
+    MessageSystemNavigationTypeAction,
 } from "../../message-system/message-system.utilities.props";
 import { MessageSystemType } from "../../message-system/types";
 import { Shortcuts } from "../shortcuts.service";

--- a/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
+++ b/packages/fast-tooling/src/message-system-service/shortcuts.service.ts
@@ -150,11 +150,6 @@ export class Shortcuts extends MessageSystemService<
                 this.dictionaryId = e.data.activeDictionaryId;
                 this.dataDictionary = e.data.dataDictionary;
                 break;
-            case MessageSystemType.dataDictionary:
-                this.dictionaryId = e.data.activeDictionaryId;
-                this.dataDictionary = e.data.dataDictionary;
-
-                break;
             case MessageSystemType.data:
                 this.dataDictionary = e.data.dataDictionary;
 
@@ -162,8 +157,6 @@ export class Shortcuts extends MessageSystemService<
             case MessageSystemType.navigation:
                 this.dictionaryId = e.data.activeDictionaryId;
                 break;
-            case MessageSystemType.navigationDictionary:
-                this.dictionaryId = e.data.activeDictionaryId;
         }
     };
 

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -12,11 +12,6 @@ import { History } from "./history.props";
  * terms are from the POV of the message system.
  */
 
-export enum MessageSystemDataDictionaryTypeAction {
-    get = "get",
-    updateActiveId = "update-active-id",
-}
-
 export enum MessageSystemDataTypeAction {
     update = "update",
     remove = "remove",
@@ -25,11 +20,6 @@ export enum MessageSystemDataTypeAction {
     removeLinkedData = "remove-linked-data",
     addLinkedData = "add-linked-data",
     reorderLinkedData = "reorder-linked-data",
-}
-
-export enum MessageSystemNavigationDictionaryTypeAction {
-    get = "get",
-    updateActiveId = "update-active-id",
 }
 
 export enum MessageSystemNavigationTypeAction {
@@ -154,24 +144,6 @@ export interface InitializeMessageOutgoing<TConfig = {}>
 }
 
 /**
- * The message to get the data dictionary
- */
-export interface GetDataDictionaryMessageIncoming<TConfig = {}>
-    extends ArbitraryMessageIncoming<TConfig> {
-    type: MessageSystemType.dataDictionary;
-    action: MessageSystemDataDictionaryTypeAction.get;
-}
-
-/**
- * The message that the data dictionary has been given
- */
-export interface GetDataDictionaryMessageOutgoing<TConfig = {}>
-    extends ArbitraryMessageOutgoing<TConfig> {
-    type: MessageSystemType.dataDictionary;
-    action: MessageSystemDataDictionaryTypeAction.get;
-}
-
-/**
  * The message that the validation should be updated
  */
 export interface UpdateValidationMessageIncoming<TConfig = {}>
@@ -216,70 +188,6 @@ export interface GetValidationMessageOutgoing<TConfig = {}>
      * @deprecated
      */
     validationErrors: ValidationError[];
-}
-
-/**
- * The message to get the navigation dictionary
- */
-export interface GetNavigationDictionaryMessageIncoming<TConfig = {}>
-    extends ArbitraryMessageIncoming<TConfig> {
-    type: MessageSystemType.navigationDictionary;
-    action: MessageSystemNavigationDictionaryTypeAction.get;
-}
-
-/**
- * The message that the navigation dictionary has been given
- */
-export interface GetNavigationDictionaryMessageOutgoing<TConfig = {}>
-    extends ArbitraryMessageOutgoing<TConfig> {
-    type: MessageSystemType.navigationDictionary;
-    action: MessageSystemNavigationDictionaryTypeAction.get;
-}
-
-/**
- * The message to update the active id of the data dictionary
- * @deprecated - this should use the MessageSystemType.navigation
- * action MessageSystemNavigationTypeAction.udpate
- */
-export interface UpdateActiveIdDataDictionaryMessageIncoming<TConfig = {}>
-    extends ArbitraryMessageIncoming<TConfig> {
-    type: MessageSystemType.dataDictionary;
-    action: MessageSystemDataDictionaryTypeAction.updateActiveId;
-    activeDictionaryId: string;
-}
-
-/**
- * The message that the active id of the data dictionary has been updated
- * @deprecated - this should use the MessageSystemType.navigation
- * action MessageSystemNavigationTypeAction.udpate
- */
-export interface UpdateActiveIdDataDictionaryMessageOutgoing<TConfig = {}>
-    extends ArbitraryMessageOutgoing<TConfig> {
-    type: MessageSystemType.dataDictionary;
-    action: MessageSystemDataDictionaryTypeAction.updateActiveId;
-}
-
-/**
- * The message to update the active id of the navigation dictionary
- * @deprecated - this should use the MessageSystemType.navigation
- * action MessageSystemNavigationTypeAction.udpate
- */
-export interface UpdateActiveIdNavigationDictionaryMessageIncoming<TConfig = {}>
-    extends ArbitraryMessageIncoming<TConfig> {
-    type: MessageSystemType.navigationDictionary;
-    action: MessageSystemNavigationDictionaryTypeAction.updateActiveId;
-    activeDictionaryId: string;
-}
-
-/**
- * The message that the active id of the navigation dictionary has been updated
- * @deprecated - this should use the MessageSystemType.navigation
- * action MessageSystemNavigationTypeAction.udpate
- */
-export interface UpdateActiveIdNavigationDictionaryMessageOutgoing<TConfig = {}>
-    extends ArbitraryMessageOutgoing<TConfig> {
-    type: MessageSystemType.navigationDictionary;
-    action: MessageSystemNavigationDictionaryTypeAction.updateActiveId;
 }
 
 /**
@@ -637,34 +545,6 @@ export interface ErrorMessageOutgoing {
 export type CustomMessage<T, OConfig> = CustomMessageIncomingOutgoing<OConfig> & T;
 
 /**
- * Incoming navigation dictionary messages to the message system
- */
-export type NavigationDictionaryMessageIncoming =
-    | GetNavigationDictionaryMessageIncoming
-    | UpdateActiveIdNavigationDictionaryMessageIncoming;
-
-/**
- * Outgoing navigation dictionary messages from the message system
- */
-export type NavigationDictionaryMessageOutgoing =
-    | GetNavigationDictionaryMessageOutgoing
-    | UpdateActiveIdNavigationDictionaryMessageOutgoing;
-
-/**
- * Incoming data dictionary messages to the message system
- */
-export type DataDictionaryMessageIncoming =
-    | GetDataDictionaryMessageIncoming
-    | UpdateActiveIdDataDictionaryMessageIncoming;
-
-/**
- * Outgoing data dictionary messages from the message system
- */
-export type DataDictionaryMessageOutgoing =
-    | GetDataDictionaryMessageOutgoing
-    | UpdateActiveIdDataDictionaryMessageOutgoing;
-
-/**
  * Incoming navigation messages to the message system
  */
 export type NavigationMessageIncoming =
@@ -721,8 +601,6 @@ export type MessageSystemIncoming<C = {}, OConfig = {}> =
     | HistoryMessageIncoming
     | SchemaDictionaryMessageIncoming
     | NavigationMessageIncoming
-    | NavigationDictionaryMessageIncoming
-    | DataDictionaryMessageIncoming
     | ValidationMessageIncoming
     | CustomMessage<C, OConfig>;
 
@@ -736,8 +614,6 @@ export type InternalMessageSystemIncoming<C = {}, OConfig = {}> =
     | InternalIncomingMessage<HistoryMessageIncoming>
     | InternalIncomingMessage<SchemaDictionaryMessageIncoming>
     | InternalIncomingMessage<NavigationMessageIncoming>
-    | InternalIncomingMessage<NavigationDictionaryMessageIncoming>
-    | InternalIncomingMessage<DataDictionaryMessageIncoming>
     | InternalIncomingMessage<ValidationMessageIncoming>
     | InternalOutgoingMessage<CustomMessage<C, OConfig>>;
 
@@ -751,8 +627,6 @@ export type MessageSystemOutgoing<C = {}, OConfig = {}> =
     | HistoryMessageOutgoing
     | SchemaDictionaryMessageOutgoing
     | NavigationMessageOutgoing
-    | NavigationDictionaryMessageOutgoing
-    | DataDictionaryMessageOutgoing
     | ValidationMessageOutgoing
     | CustomMessage<C, OConfig>;
 
@@ -767,7 +641,5 @@ export type InternalMessageSystemOutgoing<C = {}, OConfig = {}> =
     | InternalOutgoingMessage<HistoryMessageOutgoing>
     | InternalOutgoingMessage<SchemaDictionaryMessageOutgoing>
     | InternalOutgoingMessage<NavigationMessageOutgoing>
-    | InternalOutgoingMessage<NavigationDictionaryMessageOutgoing>
-    | InternalOutgoingMessage<DataDictionaryMessageOutgoing>
     | InternalOutgoingMessage<ValidationMessageOutgoing>
     | InternalOutgoingMessage<CustomMessage<C, OConfig>>;

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -5,32 +5,23 @@ import {
     AddDataMessageOutgoing,
     AddLinkedDataDataMessageOutgoing,
     AddSchemaDictionaryMessageOutgoing,
-    DataDictionaryMessageIncoming,
     DataMessageIncoming,
     DuplicateDataMessageOutgoing,
-    GetDataDictionaryMessageOutgoing,
     GetHistoryMessageIncoming,
     GetHistoryMessageOutgoing,
-    GetNavigationDictionaryMessageOutgoing,
     GetNavigationMessageOutgoing,
     InitializeMessageOutgoing,
     InternalIncomingMessage,
     InternalOutgoingMessage,
-    MessageSystemDataDictionaryTypeAction,
     MessageSystemDataTypeAction,
     MessageSystemHistoryTypeAction,
-    MessageSystemNavigationDictionaryTypeAction,
     MessageSystemNavigationTypeAction,
     MessageSystemSchemaDictionaryTypeAction,
     MessageSystemValidationTypeAction,
-    NavigationDictionaryMessageIncoming,
     NavigationMessageIncoming,
     NavigationMessageOutgoing,
     RemoveDataMessageOutgoing,
-    UpdateActiveIdDataDictionaryMessageOutgoing,
-    UpdateActiveIdNavigationDictionaryMessageOutgoing,
     UpdateDataMessageOutgoing,
-    UpdateNavigationMessageIncoming,
     UpdateValidationMessageIncoming,
     ValidationMessageIncoming,
     ValidationMessageOutgoing,
@@ -246,47 +237,6 @@ describe("getMessage", () => {
                     );
                     expect((lastItem.previous as any).activeNavigationConfigId).to.equal(
                         ""
-                    );
-                });
-            });
-            describe("navigationDictionary", () => {
-                it("should store a history item when the active dictionary ID is updated", () => {
-                    getMessage([
-                        {
-                            type: MessageSystemType.navigationDictionary,
-                            action:
-                                MessageSystemNavigationDictionaryTypeAction.updateActiveId,
-                            activeDictionaryId: "data2",
-                        } as NavigationDictionaryMessageIncoming,
-                        "",
-                    ]);
-
-                    const getHistory: GetHistoryMessageIncoming = {
-                        type: MessageSystemType.history,
-                        action: MessageSystemHistoryTypeAction.get,
-                    };
-                    const history = (getMessage([
-                        getHistory,
-                        "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
-                    const lastItemIndex = history.items.length - 1;
-                    const lastItem = history.items[lastItemIndex];
-
-                    expect(lastItem.next.type).to.equal(
-                        MessageSystemType.navigationDictionary
-                    );
-                    expect((lastItem.next as any).action).to.equal(
-                        MessageSystemNavigationDictionaryTypeAction.updateActiveId
-                    );
-                    expect((lastItem.next as any).activeDictionaryId).to.equal("data2");
-                    expect(lastItem.previous.type).to.equal(
-                        MessageSystemType.navigationDictionary
-                    );
-                    expect((lastItem.previous as any).action).to.equal(
-                        MessageSystemNavigationDictionaryTypeAction.updateActiveId
-                    );
-                    expect((lastItem.previous as any).activeDictionaryId).to.equal(
-                        "data"
                     );
                 });
             });
@@ -607,72 +557,6 @@ describe("getMessage", () => {
                             id: "data3",
                         },
                     ]);
-                });
-            });
-            describe("dataDictionary", () => {
-                it("should store a history item when the active dictionary ID is updated", () => {
-                    const schemaDictionary: SchemaDictionary = {
-                        foo: { id: "foo" },
-                    };
-                    const dataBlob: DataDictionary<unknown> = [
-                        {
-                            data: {
-                                schemaId: "foo",
-                                data: {
-                                    foo: "bar",
-                                },
-                            },
-                            data2: {
-                                schemaId: "foo",
-                                data: {},
-                            },
-                        },
-                        "data",
-                    ];
-
-                    getMessage([
-                        {
-                            type: MessageSystemType.initialize,
-                            dataDictionary: dataBlob,
-                            schemaDictionary,
-                        },
-                        "",
-                    ]);
-
-                    getMessage([
-                        {
-                            type: MessageSystemType.dataDictionary,
-                            action: MessageSystemDataDictionaryTypeAction.updateActiveId,
-                            activeDictionaryId: "data2",
-                        } as DataDictionaryMessageIncoming,
-                        "",
-                    ]);
-
-                    const getHistory: GetHistoryMessageIncoming = {
-                        type: MessageSystemType.history,
-                        action: MessageSystemHistoryTypeAction.get,
-                    };
-                    const history = (getMessage([
-                        getHistory,
-                        "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
-                    const lastItemIndex = history.items.length - 1;
-                    const lastItem = history.items[lastItemIndex];
-
-                    expect(lastItem.next.type).to.equal(MessageSystemType.dataDictionary);
-                    expect((lastItem.next as any).action).to.equal(
-                        MessageSystemDataDictionaryTypeAction.updateActiveId
-                    );
-                    expect((lastItem.next as any).activeDictionaryId).to.equal("data2");
-                    expect(lastItem.previous.type).to.equal(
-                        MessageSystemType.dataDictionary
-                    );
-                    expect((lastItem.previous as any).action).to.equal(
-                        MessageSystemDataDictionaryTypeAction.updateActiveId
-                    );
-                    expect((lastItem.previous as any).activeDictionaryId).to.equal(
-                        "data"
-                    );
                 });
             });
         });
@@ -1043,15 +927,6 @@ describe("getMessage", () => {
             expect((message[0].data as any).linkedData.length).to.equal(1);
 
             const id: string = (message[0].data as any).linkedData[0].id;
-            const dictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
 
             expect(
                 Object.keys(message[0].dataDictionary[0]).findIndex(
@@ -1060,7 +935,7 @@ describe("getMessage", () => {
                     }
                 )
             ).not.to.equal(-1);
-            expect(dictionary[0].dataDictionary[0][id].data).to.deep.equal(
+            expect(message[0].dataDictionary[0][id].data).to.deep.equal(
                 linkedData[0].data
             );
             expect(message[0].linkedDataIds).to.deep.equal([{ id }]);
@@ -1119,28 +994,19 @@ describe("getMessage", () => {
 
             const id: string = (message[0].dataDictionary[0].abc.data as any)
                 .linkedData[0].id;
-            const dictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
 
             expect(
-                Object.keys(dictionary[0].dataDictionary[0]).findIndex(
+                Object.keys(message[0].dataDictionary[0]).findIndex(
                     (dictionaryKey: string) => {
                         return dictionaryKey === id;
                     }
                 )
             ).not.to.equal(-1);
-            expect(dictionary[0].dataDictionary[0][id].data).to.deep.equal(
+            expect(message[0].dataDictionary[0][id].data).to.deep.equal(
                 linkedData[0].data
             );
             expect(
-                (dictionary[0].dataDictionary[0].abc.data as any).linkedData
+                (message[0].dataDictionary[0].abc.data as any).linkedData
             ).to.deep.equal([{ id }]);
         });
         it("should add linkedData to an existing array of linkedData items", () => {
@@ -1199,24 +1065,15 @@ describe("getMessage", () => {
             expect((message[0].data as any).linkedData.length).to.equal(2);
 
             const id: string = (message[0].data as any).linkedData[1].id;
-            const dictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
 
             expect(
-                Object.keys(dictionary[0].dataDictionary[0]).findIndex(
+                Object.keys(message[0].dataDictionary[0]).findIndex(
                     (dictionaryKey: string) => {
                         return dictionaryKey === id;
                     }
                 )
             ).not.to.equal(-1);
-            expect(dictionary[0].dataDictionary[0][id].data).to.deep.equal(
+            expect(message[0].dataDictionary[0][id].data).to.deep.equal(
                 linkedData[0].data
             );
         });
@@ -1276,24 +1133,15 @@ describe("getMessage", () => {
             expect((message[0].data as any).linkedData.length).to.equal(2);
 
             const id: string = (message[0].data as any).linkedData[0].id;
-            const dictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
 
             expect(
-                Object.keys(dictionary[0].dataDictionary[0]).findIndex(
+                Object.keys(message[0].dataDictionary[0]).findIndex(
                     (dictionaryKey: string) => {
                         return dictionaryKey === id;
                     }
                 )
             ).not.to.equal(-1);
-            expect(dictionary[0].dataDictionary[0][id].data).to.deep.equal(
+            expect(message[0].dataDictionary[0][id].data).to.deep.equal(
                 linkedData[0].data
             );
         });
@@ -1351,18 +1199,9 @@ describe("getMessage", () => {
             const id: string = (message[0].data as any).linkedData[0].id;
             const nestedId: string = (message[0].dataDictionary[0][id].data as any)
                 .linkedData[0].id;
-            const dictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
 
             expect(
-                Object.keys(dictionary[0].dataDictionary[0]).findIndex(
+                Object.keys(message[0].dataDictionary[0]).findIndex(
                     (dictionaryKey: string) => {
                         return dictionaryKey === id;
                     }
@@ -1826,199 +1665,6 @@ describe("getMessage", () => {
 
             expect(message[0].navigation).to.deep.equal(
                 navigationDictionary[0][message[0].activeDictionaryId]
-            );
-        });
-    });
-    describe("dataDictionary", () => {
-        it("should return messages sent to get the data dictionary", () => {
-            const dataBlob: DataDictionary<unknown> = [
-                {
-                    data: {
-                        schemaId: "foo",
-                        data: {
-                            foo: "bar",
-                        },
-                    },
-                },
-                "data",
-            ];
-            const schemaDictionary: SchemaDictionary = {
-                foo: { id: "foo" },
-            };
-            getMessage([
-                {
-                    type: MessageSystemType.initialize,
-                    data: dataBlob,
-                    schemaDictionary,
-                },
-                "",
-            ]);
-            const getDataDictionary: InternalOutgoingMessage<GetDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetDataDictionaryMessageOutgoing>;
-
-            expect(getDataDictionary[0].type).to.equal(MessageSystemType.dataDictionary);
-            expect(getDataDictionary[0].action).to.equal(
-                MessageSystemDataDictionaryTypeAction.get
-            );
-            expect(getDataDictionary[0].dataDictionary).to.deep.equal(dataBlob);
-            expect(getDataDictionary[0].activeDictionaryId).to.equal(dataBlob[1]);
-        });
-        it("should return messages set to update the active id of the data dictionary", () => {
-            const dataBlob: DataDictionary<unknown> = [
-                {
-                    abc: {
-                        schemaId: "foo",
-                        data: {
-                            foo: [
-                                {
-                                    id: "def",
-                                },
-                            ],
-                        },
-                    },
-                    def: {
-                        schemaId: "foo",
-                        parent: {
-                            id: "abc",
-                            dataLocation: "foo",
-                        },
-                        data: {
-                            bat: "baz",
-                        },
-                    },
-                },
-                "abc",
-            ];
-            const schemaDictionary: SchemaDictionary = {
-                foo: { id: "foo" },
-            };
-            getMessage([
-                {
-                    type: MessageSystemType.initialize,
-                    data: dataBlob,
-                    schemaDictionary,
-                },
-                "",
-            ]);
-
-            const updateDataDictionaryActiveId: InternalOutgoingMessage<UpdateActiveIdDataDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.dataDictionary,
-                        action: MessageSystemDataDictionaryTypeAction.updateActiveId,
-                        activeDictionaryId: "def",
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<UpdateActiveIdDataDictionaryMessageOutgoing>;
-
-            expect(updateDataDictionaryActiveId[0].type).to.equal(
-                MessageSystemType.dataDictionary
-            );
-            expect(updateDataDictionaryActiveId[0].action).to.equal(
-                MessageSystemDataDictionaryTypeAction.updateActiveId
-            );
-            expect(updateDataDictionaryActiveId[0].activeDictionaryId).to.equal("def");
-        });
-    });
-    describe("navigationDictionary", () => {
-        it("should return messages sent to get the navigation dictionary", () => {
-            const dataBlob: DataDictionary<unknown> = [
-                {
-                    data: {
-                        schemaId: "foo",
-                        data: {
-                            foo: "bar",
-                        },
-                    },
-                },
-                "data",
-            ];
-            const schemaDictionary: SchemaDictionary = {
-                foo: { id: "foo" },
-            };
-            getMessage([
-                {
-                    type: MessageSystemType.initialize,
-                    data: dataBlob,
-                    schemaDictionary,
-                },
-                "",
-            ]);
-            const getNavigationDictionary: InternalOutgoingMessage<GetNavigationDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.navigationDictionary,
-                        action: MessageSystemNavigationDictionaryTypeAction.get,
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<GetNavigationDictionaryMessageOutgoing>;
-
-            expect(getNavigationDictionary[0].type).to.equal(
-                MessageSystemType.navigationDictionary
-            );
-            expect(getNavigationDictionary[0].action).to.equal(
-                MessageSystemNavigationDictionaryTypeAction.get
-            );
-            expect(getNavigationDictionary[0].navigationDictionary).not.to.equal(
-                undefined
-            );
-            expect(getNavigationDictionary[0].activeDictionaryId).not.to.equal(undefined);
-        });
-        it("should return messages set to update the active id of the navigation dictionary", () => {
-            const dataBlob: DataDictionary<unknown> = [
-                {
-                    data: {
-                        schemaId: "foo",
-                        data: {
-                            foo: "bar",
-                        },
-                    },
-                },
-                "data",
-            ];
-            const schemaDictionary: SchemaDictionary = {
-                foo: { id: "foo" },
-            };
-            getMessage([
-                {
-                    type: MessageSystemType.initialize,
-                    data: dataBlob,
-                    schemaDictionary,
-                },
-                "",
-            ]);
-
-            const updateNavigationDictionaryActiveId: InternalOutgoingMessage<UpdateActiveIdNavigationDictionaryMessageOutgoing> = getMessage(
-                [
-                    {
-                        type: MessageSystemType.navigationDictionary,
-                        action:
-                            MessageSystemNavigationDictionaryTypeAction.updateActiveId,
-                        activeDictionaryId: "nav2",
-                    },
-                    "",
-                ]
-            ) as InternalOutgoingMessage<
-                UpdateActiveIdNavigationDictionaryMessageOutgoing
-            >;
-
-            expect(updateNavigationDictionaryActiveId[0].type).to.equal(
-                MessageSystemType.navigationDictionary
-            );
-            expect(updateNavigationDictionaryActiveId[0].action).to.equal(
-                MessageSystemNavigationDictionaryTypeAction.updateActiveId
-            );
-            expect(updateNavigationDictionaryActiveId[0].activeDictionaryId).to.equal(
-                "nav2"
             );
         });
     });

--- a/packages/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.ts
@@ -11,8 +11,6 @@ import { getLinkedDataDictionary, getLinkedDataList } from "./data";
 import { MessageSystemType } from "./types";
 import {
     CustomMessage,
-    DataDictionaryMessageIncoming,
-    DataDictionaryMessageOutgoing,
     DataMessageIncoming,
     DataMessageOutgoing,
     ErrorMessageOutgoing,
@@ -22,16 +20,12 @@ import {
     InternalMessageSystemIncoming,
     InternalMessageSystemOutgoing,
     InternalOutgoingMessage,
-    MessageSystemDataDictionaryTypeAction,
     MessageSystemDataTypeAction,
     MessageSystemHistoryTypeAction,
     MessageSystemIncoming,
-    MessageSystemNavigationDictionaryTypeAction,
     MessageSystemNavigationTypeAction,
     MessageSystemSchemaDictionaryTypeAction,
     MessageSystemValidationTypeAction,
-    NavigationDictionaryMessageIncoming,
-    NavigationDictionaryMessageOutgoing,
     NavigationMessageIncoming,
     NavigationMessageOutgoing,
     SchemaDictionaryMessageIncoming,
@@ -130,130 +124,6 @@ function getValidationMessage(
                 historyId,
                 validation,
                 validationErrors: validation[data.dictionaryId],
-                options: data.options,
-            };
-    }
-}
-
-/**
- * Gets a previous data dictionary message based on an incoming message
- */
-function getDataDictionaryPreviousMessage(
-    data: DataDictionaryMessageIncoming
-): DataDictionaryMessageIncoming | null {
-    switch (data.action) {
-        case MessageSystemDataDictionaryTypeAction.updateActiveId:
-            return {
-                type: MessageSystemType.dataDictionary,
-                action: MessageSystemDataDictionaryTypeAction.updateActiveId,
-                activeDictionaryId,
-                options: data.options,
-            };
-    }
-
-    return null;
-}
-
-/**
- * Handles all data dictionary messages
- */
-function getDataDictionaryMessage(
-    data: DataDictionaryMessageIncoming,
-    historyId: string
-): DataDictionaryMessageOutgoing {
-    switch (data.action) {
-        case MessageSystemDataDictionaryTypeAction.get:
-            return {
-                type: MessageSystemType.dataDictionary,
-                action: MessageSystemDataDictionaryTypeAction.get,
-                dataDictionary,
-                navigationDictionary,
-                activeHistoryIndex,
-                activeNavigationConfigId,
-                schemaDictionary,
-                historyId,
-                activeDictionaryId,
-                dictionaryId: activeDictionaryId,
-                validation,
-                options: data.options,
-            };
-        case MessageSystemDataDictionaryTypeAction.updateActiveId:
-            activeDictionaryId = data.activeDictionaryId;
-
-            return {
-                type: MessageSystemType.dataDictionary,
-                action: MessageSystemDataDictionaryTypeAction.updateActiveId,
-                dataDictionary,
-                navigationDictionary,
-                activeHistoryIndex,
-                activeNavigationConfigId,
-                schemaDictionary,
-                historyId,
-                activeDictionaryId,
-                dictionaryId: activeDictionaryId,
-                validation,
-                options: data.options,
-            };
-    }
-}
-
-/**
- * Gets a previous navigation dictionary message based on an incoming message
- */
-function getNavigationDictionaryPreviousMessage(
-    data: NavigationDictionaryMessageIncoming
-): NavigationDictionaryMessageIncoming | null {
-    switch (data.action) {
-        case MessageSystemNavigationDictionaryTypeAction.updateActiveId:
-            return {
-                type: MessageSystemType.navigationDictionary,
-                action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
-                activeDictionaryId,
-                options: data.options,
-            };
-    }
-
-    return null;
-}
-
-/**
- * Handles all navigation dictionary messages
- */
-function getNavigationDictionaryMessage(
-    data: NavigationDictionaryMessageIncoming,
-    historyId: string
-): NavigationDictionaryMessageOutgoing {
-    switch (data.action) {
-        case MessageSystemNavigationDictionaryTypeAction.get:
-            return {
-                type: MessageSystemType.navigationDictionary,
-                action: MessageSystemNavigationDictionaryTypeAction.get,
-                dataDictionary,
-                navigationDictionary,
-                activeHistoryIndex,
-                activeNavigationConfigId,
-                schemaDictionary,
-                historyId,
-                activeDictionaryId,
-                dictionaryId: activeDictionaryId,
-                validation,
-                options: data.options,
-            };
-        case MessageSystemNavigationDictionaryTypeAction.updateActiveId:
-            activeDictionaryId = data.activeDictionaryId;
-
-            return {
-                type: MessageSystemType.navigationDictionary,
-                action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
-                dataDictionary,
-                navigationDictionary,
-                activeHistoryIndex,
-                activeNavigationConfigId,
-                schemaDictionary,
-                historyId,
-                activeDictionaryId,
-                dictionaryId: activeDictionaryId,
-                validation,
                 options: data.options,
             };
     }
@@ -982,16 +852,6 @@ export function getMessage<C = {}>(
                 data[1],
             ] as InternalOutgoingMessage<DataMessageOutgoing>;
         }
-        case MessageSystemType.dataDictionary:
-            updateHistory(data[0], getDataDictionaryPreviousMessage(data[0]), historyId);
-
-            return [
-                getDataDictionaryMessage(
-                    data[0] as DataDictionaryMessageIncoming,
-                    historyId
-                ),
-                data[1],
-            ] as InternalOutgoingMessage<DataDictionaryMessageOutgoing>;
         case MessageSystemType.navigation:
             updateHistory(data[0], getNavigationPreviousMessage(data[0]), historyId);
 
@@ -999,20 +859,6 @@ export function getMessage<C = {}>(
                 getNavigationMessage(data[0] as NavigationMessageIncoming, historyId),
                 data[1],
             ] as InternalOutgoingMessage<NavigationMessageOutgoing>;
-        case MessageSystemType.navigationDictionary:
-            updateHistory(
-                data[0],
-                getNavigationDictionaryPreviousMessage(data[0]),
-                historyId
-            );
-
-            return [
-                getNavigationDictionaryMessage(
-                    data[0] as NavigationDictionaryMessageIncoming,
-                    historyId
-                ),
-                data[1],
-            ] as InternalOutgoingMessage<NavigationDictionaryMessageOutgoing>;
         case MessageSystemType.validation:
             return [
                 getValidationMessage(data[0] as ValidationMessageIncoming, historyId),

--- a/packages/fast-tooling/src/message-system/types.ts
+++ b/packages/fast-tooling/src/message-system/types.ts
@@ -1,11 +1,9 @@
 export enum MessageSystemType {
     custom = "custom",
     data = "data",
-    dataDictionary = "data-dictionary",
     error = "error",
     history = "history",
     navigation = "navigation",
-    navigationDictionary = "navigation-dictionary",
     initialize = "initialize",
     validation = "validation",
     schemaDictionary = "schema-dictionary",


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change removes redundant `MessageSystemType` messages. This should simplify the message system interfaces as they are now always sending state data per updates from https://github.com/microsoft/fast-tooling/pull/167.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->
Closes #168

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- #158