### PR TITLE
Allow multiple outgoing messages to be sent

### DIFF
--- a/change/@microsoft-fast-tooling-0d372a5c-657b-49f6-99f5-58a001658c9d.json
+++ b/change/@microsoft-fast-tooling-0d372a5c-657b-49f6-99f5-58a001658c9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow multiple outgoing messages to be sent",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/app/examples/shortcuts/index.html
+++ b/packages/fast-tooling/app/examples/shortcuts/index.html
@@ -41,6 +41,14 @@
                         <td><code>Ctrl + D</code></td>
                         <td>Duplicates the text linked data item</td>
                     </tr>
+                    <tr>
+                        <td><code>Ctrl + Z</code></td>
+                        <td>Undo the last action</td>
+                    </tr>
+                    <tr>
+                        <td><code>Ctrl + Shift + Z</code></td>
+                        <td>Redo the last action</td>
+                    </tr>
                 </tbody>
             </table>
             <br />

--- a/packages/fast-tooling/app/examples/shortcuts/index.ts
+++ b/packages/fast-tooling/app/examples/shortcuts/index.ts
@@ -1,9 +1,11 @@
 import {
     MessageSystem,
     MessageSystemType,
-    MessageSystemNavigationDictionaryTypeAction,
+    MessageSystemNavigationTypeAction,
     ShortcutsActionDelete,
     ShortcutsActionDuplicate,
+    ShortcutsActionUndo,
+    ShortcutsActionRedo,
 } from "../../../src";
 import { Shortcuts } from "../../../src/message-system-service/shortcuts.service";
 import dataDictionaryConfig from "./data-dictionary-config";
@@ -47,9 +49,10 @@ if ((window as any).Worker) {
         onMessage: handleMessageSystem,
     });
     fastMessageSystem.postMessage({
-        type: MessageSystemType.navigationDictionary,
-        action: MessageSystemNavigationDictionaryTypeAction.updateActiveId,
+        type: MessageSystemType.navigation,
+        action: MessageSystemNavigationTypeAction.update,
         activeDictionaryId: "text",
+        activeNavigationConfigId: "",
     });
 
     fastShortcuts = new Shortcuts({
@@ -58,6 +61,8 @@ if ((window as any).Worker) {
         actions: [
             ShortcutsActionDelete(fastMessageSystem),
             ShortcutsActionDuplicate(fastMessageSystem),
+            ShortcutsActionRedo(fastMessageSystem),
+            ShortcutsActionUndo(fastMessageSystem),
         ],
     });
 }

--- a/packages/fast-tooling/src/message-system/data.props.ts
+++ b/packages/fast-tooling/src/message-system/data.props.ts
@@ -122,7 +122,7 @@ export interface LinkedDataDictionaryUpdate {
  * 4. If in the case of 3. the active dictionary ID has no parent (is the root ID), send an error message
  */
 export enum RemoveLinkedDataParentType {
-    activeDictionaryId,
-    activeDictionaryIdParent,
-    suppliedDictionaryId,
+    activeDictionaryId = "active-dictionary-id",
+    activeDictionaryIdParent = "active-dictionary-id-parent",
+    suppliedDictionaryId = "supplied-dictionary-id",
 }

--- a/packages/fast-tooling/src/message-system/history.props.ts
+++ b/packages/fast-tooling/src/message-system/history.props.ts
@@ -2,7 +2,7 @@ import { MessageSystemIncoming } from "./message-system.utilities.props";
 
 export interface HistoryItem {
     next: MessageSystemIncoming;
-    previous: MessageSystemIncoming;
+    previous: Array<MessageSystemIncoming>;
     id: string;
 }
 

--- a/packages/fast-tooling/src/message-system/message-system.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.spec.ts
@@ -262,7 +262,7 @@ describe("MessageSystem", () => {
         messageSystem.postMessage({} as any);
 
         messageSystem["onMessage"]({
-            data: ["foo", messageSystem["messageQueue"][1][0]],
+            data: [["foo", messageSystem["messageQueue"][1][0]]],
         } as any);
         expect(messageSystem["messageQueue"][1]).to.have.length(0);
     });
@@ -314,7 +314,7 @@ describe("MessageSystem", () => {
         expect(registeredCallback).to.have.been.called.exactly(0);
 
         messageSystem["messageQueue"] = [{}, ["bar"]];
-        messageSystem["onMessage"]({ data: ["foo", "bar"] } as any);
+        messageSystem["onMessage"]({ data: [["foo", "bar"]] } as any);
 
         expect(registeredCallback).to.have.been.called.exactly(1);
     });

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -244,6 +244,14 @@ export interface AddLinkedDataDataMessageIncoming<TConfig = {}>
     index?: number;
     dataLocation: string;
     linkedData: Array<Data<unknown>>;
+    /**
+     * If there is a list of previous IDs used for this linked data,
+     * utilize these instead of generated them.
+     *
+     * Warning: this should only be used internally or if the user has a self
+     * curated ID system they would prefer to use over the auto-generated one.
+     */
+    originalLinkedDataIds?: Array<LinkedData>;
 }
 
 /**

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -45,15 +45,15 @@ describe("getMessage", () => {
             ];
             const historyMessage = getMessage(getHistory);
 
-            expect(historyMessage[0].type).to.equal(MessageSystemType.history);
-            expect((historyMessage[0] as GetHistoryMessageOutgoing).action).to.equal(
+            expect(historyMessage[0][0].type).to.equal(MessageSystemType.history);
+            expect((historyMessage[0][0] as GetHistoryMessageOutgoing).action).to.equal(
                 MessageSystemHistoryTypeAction.get
             );
             expect(
-                (historyMessage[0] as GetHistoryMessageOutgoing).history.items.length
+                (historyMessage[0][0] as GetHistoryMessageOutgoing).history.items.length
             ).to.equal(0);
             expect(
-                (historyMessage[0] as GetHistoryMessageOutgoing).history.limit
+                (historyMessage[0][0] as GetHistoryMessageOutgoing).history.limit
             ).to.equal(30);
         });
         it("should update the history when a new message has been sent", () => {
@@ -94,7 +94,7 @@ describe("getMessage", () => {
             };
 
             expect(
-                (getMessage([getHistory, ""])[0] as GetHistoryMessageOutgoing).history
+                (getMessage([getHistory, ""])[0][0] as GetHistoryMessageOutgoing).history
                     .items.length
             ).to.equal(1);
         });
@@ -139,16 +139,16 @@ describe("getMessage", () => {
             };
 
             expect(
-                (getMessage([getHistory, ""])[0] as GetHistoryMessageOutgoing).history
+                (getMessage([getHistory, ""])[0][0] as GetHistoryMessageOutgoing).history
                     .items.length
             ).to.equal(30);
 
             const lastItem = (getMessage([
                 getHistory,
                 "",
-            ])[0] as GetHistoryMessageOutgoing).history.items[29];
+            ])[0][0] as GetHistoryMessageOutgoing).history.items[29];
 
-            expect(lastItem.previous).to.not.equal(undefined);
+            expect(lastItem.previous[0]).to.not.equal(undefined);
             expect(lastItem.next).to.not.equal(undefined);
         });
         it("should update the active history index if the previous message has been sent", () => {
@@ -199,8 +199,10 @@ describe("getMessage", () => {
                 action: MessageSystemHistoryTypeAction.get,
             };
 
-            const history = (getMessage([getHistory, ""])[0] as GetHistoryMessageOutgoing)
-                .activeHistoryIndex;
+            const history = (getMessage([
+                getHistory,
+                "",
+            ])[0][0] as GetHistoryMessageOutgoing).activeHistoryIndex;
 
             expect(history).to.equal(28);
         });
@@ -247,11 +249,11 @@ describe("getMessage", () => {
                 "",
             ]);
 
-            expect(previousMessage[0].type).to.equal(MessageSystemType.navigation);
-            expect((previousMessage[0] as any).action).to.equal(
+            expect(previousMessage[0][0].type).to.equal(MessageSystemType.navigation);
+            expect((previousMessage[0][0] as any).action).to.equal(
                 MessageSystemNavigationTypeAction.update
             );
-            expect((previousMessage[0] as any).activeDictionaryId).to.equal("data48");
+            expect((previousMessage[0][0] as any).activeDictionaryId).to.equal("data48");
         });
         it("should update the active history index if the next message has been sent", () => {
             const schemaDictionary: SchemaDictionary = {
@@ -311,8 +313,10 @@ describe("getMessage", () => {
                 action: MessageSystemHistoryTypeAction.get,
             };
 
-            const history = (getMessage([getHistory, ""])[0] as GetHistoryMessageOutgoing)
-                .activeHistoryIndex;
+            const history = (getMessage([
+                getHistory,
+                "",
+            ])[0][0] as GetHistoryMessageOutgoing).activeHistoryIndex;
 
             expect(history).to.equal(24);
         });
@@ -369,11 +373,11 @@ describe("getMessage", () => {
                 "",
             ]);
 
-            expect(nextMessage[0].type).to.equal(MessageSystemType.navigation);
-            expect((nextMessage[0] as any).action).to.equal(
+            expect(nextMessage[0][0].type).to.equal(MessageSystemType.navigation);
+            expect((nextMessage[0][0] as any).action).to.equal(
                 MessageSystemNavigationTypeAction.update
             );
-            expect((nextMessage[0] as any).activeDictionaryId).to.equal("data43");
+            expect((nextMessage[0][0] as any).activeDictionaryId).to.equal("data43");
         });
         it("should remove history items that are no longer relevent if a new data or navigation update has been sent", () => {
             const schemaDictionary: SchemaDictionary = {
@@ -434,7 +438,10 @@ describe("getMessage", () => {
                 action: MessageSystemHistoryTypeAction.get,
             };
 
-            const history = getMessage([getHistory, ""])[0] as GetHistoryMessageOutgoing;
+            const history = getMessage([
+                getHistory,
+                "",
+            ])[0][0] as GetHistoryMessageOutgoing;
 
             expect(history.activeHistoryIndex).to.equal(24);
             expect(history.history.items.length).to.equal(25);
@@ -509,7 +516,7 @@ describe("getMessage", () => {
                     const items = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history.items;
+                    ])[0][0] as GetHistoryMessageOutgoing).history.items;
                     const lastItemIndex = items.length - 1;
                     const lastItem = items[lastItemIndex];
 
@@ -518,16 +525,18 @@ describe("getMessage", () => {
                         action: MessageSystemNavigationTypeAction.update,
                         activeDictionaryId: "data2",
                     });
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.navigation);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(
+                        MessageSystemType.navigation
+                    );
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemNavigationTypeAction.update
                     );
-                    expect((lastItem.previous as any).activeDictionaryId).to.equal(
+                    expect((lastItem.previous[0] as any).activeDictionaryId).to.equal(
                         "data"
                     );
-                    expect((lastItem.previous as any).activeNavigationConfigId).to.equal(
-                        ""
-                    );
+                    expect(
+                        (lastItem.previous[0] as any).activeNavigationConfigId
+                    ).to.equal("");
                 });
             });
             describe("data", () => {
@@ -548,7 +557,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -557,11 +566,11 @@ describe("getMessage", () => {
                         MessageSystemDataTypeAction.duplicate
                     );
                     expect((lastItem.next as any).sourceDataLocation).to.equal("foo");
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.remove
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("foo[0]");
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal("foo[0]");
                 });
                 it("should store a history item when data has been removed", () => {
                     getMessage([
@@ -580,7 +589,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -589,13 +598,15 @@ describe("getMessage", () => {
                         MessageSystemDataTypeAction.remove
                     );
                     expect((lastItem.next as any).dataLocation).to.equal("foo");
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.add
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("foo");
-                    expect((lastItem.previous as any).data).to.equal("bar");
-                    expect((lastItem.previous as any).dataType).to.equal(DataType.string);
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal("foo");
+                    expect((lastItem.previous[0] as any).data).to.equal("bar");
+                    expect((lastItem.previous[0] as any).dataType).to.equal(
+                        DataType.string
+                    );
                 });
                 it("should store a history item when data has been added", () => {
                     getMessage([
@@ -616,7 +627,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -627,11 +638,11 @@ describe("getMessage", () => {
                     expect((lastItem.next as any).dataLocation).to.equal("bat");
                     expect((lastItem.next as any).data).to.equal(42);
                     expect((lastItem.next as any).dataType).to.equal(DataType.number);
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.remove
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("bat");
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal("bat");
                 });
                 it("should store a history item when data has been updated", () => {
                     getMessage([
@@ -652,7 +663,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -663,13 +674,13 @@ describe("getMessage", () => {
                     expect((lastItem.next as any).dataLocation).to.equal("foo");
                     expect((lastItem.next as any).data).to.equal("baz");
                     expect((lastItem.next as any).dictionaryId).to.equal("data");
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.update
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("foo");
-                    expect((lastItem.previous as any).data).to.equal("bar");
-                    expect((lastItem.previous as any).dictionaryId).to.equal("data");
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal("foo");
+                    expect((lastItem.previous[0] as any).data).to.equal("bar");
+                    expect((lastItem.previous[0] as any).dictionaryId).to.equal("data");
                 });
                 it("should store a history item when linked data has been added", () => {
                     getMessage([
@@ -703,7 +714,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -726,14 +737,16 @@ describe("getMessage", () => {
                         },
                     ]);
                     expect((lastItem.next as any).dictionaryId).to.equal("data");
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.removeLinkedData
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("children");
-                    expect(Array.isArray((lastItem.previous as any).linkedData)).to.be
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal(
+                        "children"
+                    );
+                    expect(Array.isArray((lastItem.previous[0] as any).linkedData)).to.be
                         .true;
-                    expect((lastItem.previous as any).dictionaryId).to.equal("data");
+                    expect((lastItem.previous[0] as any).dictionaryId).to.equal("data");
                 });
                 it("should store a history item when linked data has been removed", () => {
                     getMessage([
@@ -759,7 +772,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -775,12 +788,14 @@ describe("getMessage", () => {
                         },
                     ]);
                     expect((lastItem.next as any).dictionaryId).to.equal("data");
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.addLinkedData
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("children");
-                    expect((lastItem.previous as any).linkedData).to.deep.equal([
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal(
+                        "children"
+                    );
+                    expect((lastItem.previous[0] as any).linkedData).to.deep.equal([
                         {
                             schemaId: "foo",
                             data: {},
@@ -790,7 +805,7 @@ describe("getMessage", () => {
                             },
                         },
                     ]);
-                    expect((lastItem.previous as any).dictionaryId).to.equal("data");
+                    expect((lastItem.previous[0] as any).dictionaryId).to.equal("data");
                 });
                 it("should store a history item when linked has been reordered", () => {
                     getMessage([
@@ -817,7 +832,7 @@ describe("getMessage", () => {
                     const history = (getMessage([
                         getHistory,
                         "",
-                    ])[0] as GetHistoryMessageOutgoing).history;
+                    ])[0][0] as GetHistoryMessageOutgoing).history;
                     const lastItemIndex = history.items.length - 1;
                     const lastItem = history.items[lastItemIndex];
 
@@ -834,12 +849,14 @@ describe("getMessage", () => {
                             id: "data2",
                         },
                     ]);
-                    expect(lastItem.previous.type).to.equal(MessageSystemType.data);
-                    expect((lastItem.previous as any).action).to.equal(
+                    expect(lastItem.previous[0].type).to.equal(MessageSystemType.data);
+                    expect((lastItem.previous[0] as any).action).to.equal(
                         MessageSystemDataTypeAction.reorderLinkedData
                     );
-                    expect((lastItem.previous as any).dataLocation).to.equal("children");
-                    expect((lastItem.previous as any).linkedData).to.deep.equal([
+                    expect((lastItem.previous[0] as any).dataLocation).to.equal(
+                        "children"
+                    );
+                    expect((lastItem.previous[0] as any).linkedData).to.deep.equal([
                         {
                             id: "data2",
                         },
@@ -876,8 +893,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<InitializeMessageOutgoing>;
-
+            )[0] as InternalOutgoingMessage<InitializeMessageOutgoing>;
             expect(message[0].type).to.equal(MessageSystemType.initialize);
             expect(message[0].data).to.equal(dataBlob[0][dataBlob[1]].data);
             expect(message[0].schema).to.equal(schemaDictionary["foo"]);
@@ -907,7 +923,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<InitializeMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<InitializeMessageOutgoing>;
 
             expect(message[0].type).to.equal(MessageSystemType.initialize);
             expect(message[0].data).to.equal(dataBlob[0][dataBlob[1]].data);
@@ -945,7 +961,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<InitializeMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<InitializeMessageOutgoing>;
 
             expect(message[0].type).to.equal(MessageSystemType.initialize);
             expect(message[0].activeDictionaryId).to.equal("data2");
@@ -982,7 +998,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<DuplicateDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<DuplicateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ foo: ["bar", "bar"] });
         });
@@ -1016,7 +1032,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<RemoveDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<RemoveDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({});
         });
@@ -1048,7 +1064,7 @@ describe("getMessage", () => {
                     dataType: DataType.object,
                 },
                 "",
-            ]) as InternalOutgoingMessage<AddDataMessageOutgoing>;
+            ])[0] as InternalOutgoingMessage<AddDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "world" });
         });
@@ -1081,7 +1097,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "venus" });
         });
@@ -1114,7 +1130,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "venus" });
             expect(message[0].dictionaryId).to.equal("data");
@@ -1153,7 +1169,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<UpdateDataMessageOutgoing>;
 
             expect(message[0].data).to.deep.equal({ hello: "venus" });
             expect(message[0].dictionaryId).to.equal("bar");
@@ -1211,7 +1227,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(Array.isArray((message[0].data as any).linkedData)).to.equal(true);
             expect((message[0].data as any).linkedData.length).to.equal(1);
@@ -1273,7 +1289,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(
                 Array.isArray((message[0].dataDictionary[0].abc.data as any).linkedData)
@@ -1349,7 +1365,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(Array.isArray((message[0].data as any).linkedData)).to.equal(true);
             expect((message[0].data as any).linkedData.length).to.equal(2);
@@ -1417,7 +1433,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(Array.isArray((message[0].data as any).linkedData)).to.equal(true);
             expect((message[0].data as any).linkedData.length).to.equal(2);
@@ -1481,7 +1497,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(Array.isArray((message[0].data as any).linkedData)).to.equal(true);
             expect((message[0].data as any).linkedData.length).to.equal(1);
@@ -1545,7 +1561,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect((message[0].data as any).linkedData).to.deep.equal([]);
         });
@@ -1602,7 +1618,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(
                 (message[0].dataDictionary[0].data.data as any).linkedData
@@ -1679,7 +1695,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect((message[0].data as any).linkedData).to.deep.equal([]);
             expect(message[0].dataDictionary).to.deep.equal([
@@ -1760,7 +1776,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect((message[0].data as any).linkedData).to.deep.equal([]);
             expect(message[0].dataDictionary).to.deep.equal([
@@ -1815,7 +1831,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(message[0].type).to.equal(MessageSystemType.error);
             expect((message[0] as any).message).to.equal(removeRootDataNodeErrorMessage);
@@ -1878,7 +1894,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddLinkedDataDataMessageOutgoing>;
 
             expect(Array.isArray((message[0].data as any).linkedData)).to.equal(true);
             expect((message[0].data as any).linkedData.length).to.equal(2);
@@ -1900,7 +1916,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<NavigationMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<NavigationMessageOutgoing>;
 
             expect(message[0].type).to.equal(MessageSystemType.navigation);
             expect(message[0].action).to.equal(MessageSystemNavigationTypeAction.update);
@@ -1941,7 +1957,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<GetNavigationMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<GetNavigationMessageOutgoing>;
 
             expect(message[0].type).to.equal(MessageSystemType.navigation);
             expect(message[0].action).to.equal(MessageSystemNavigationTypeAction.get);
@@ -1997,7 +2013,7 @@ describe("getMessage", () => {
                     },
                     "",
                 ]
-            ) as InternalOutgoingMessage<AddSchemaDictionaryMessageOutgoing>;
+            )[0] as InternalOutgoingMessage<AddSchemaDictionaryMessageOutgoing>;
 
             expect(addedSchemaDictionary[0].type).to.equal(
                 MessageSystemType.schemaDictionary
@@ -2025,7 +2041,7 @@ describe("getMessage", () => {
                 },
                 "",
             ];
-            const message = getMessage(validationUpdate) as InternalOutgoingMessage<
+            const message = getMessage(validationUpdate)[0] as InternalOutgoingMessage<
                 ValidationMessageOutgoing
             >;
 
@@ -2063,7 +2079,7 @@ describe("getMessage", () => {
 
             getMessage(getValidation);
 
-            const message = getMessage(validationUpdate) as InternalOutgoingMessage<
+            const message = getMessage(validationUpdate)[0] as InternalOutgoingMessage<
                 ValidationMessageOutgoing
             >;
 
@@ -2083,7 +2099,7 @@ describe("getMessage", () => {
                 "",
             ];
 
-            expect(getMessage(customMessage)).to.deep.equal(customMessage);
+            expect(getMessage(customMessage)).to.deep.equal([customMessage]);
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change makes it so that all outgoing messages are an array of messages. This will allow for a single message update to create multiple messages that are then sent out. As this is dealt with internally, there are no breaking changes.

This change also adds a manual testing section for the new undo/redo alpha released shortcuts.

### 🎫 Issues

<!---
List and link relevant issues here using the keyword "closes"
if this PR will close an issue, eg. closes #411
-->

Resolves #179

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
This should now enable, in the manual testing app, seeing "delete" shortcut action followed by "undo".

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- More robust testing and implementation work is needed to ensure previous and next (undo/redo) maneuvering through the history stack does not cause errors to throw