### PR TITLE
Ensure that null messages are not sent

### DIFF
--- a/change/@microsoft-fast-tooling-c3ce3740-2853-4bfa-aa43-6b1bf6c8f251.json
+++ b/change/@microsoft-fast-tooling-c3ce3740-2853-4bfa-aa43-6b1bf6c8f251.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Ensure that null messages are not sent",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/app/examples/shortcuts/index.html
+++ b/packages/fast-tooling/app/examples/shortcuts/index.html
@@ -52,6 +52,10 @@
                 </tbody>
             </table>
             <br />
+            <h4>
+                Active Dictionary ID:
+                <span id="activeid"></span>
+            </h4>
             <input id="input" type="text" disabled />
             <pre id="data"></pre>
         </div>

--- a/packages/fast-tooling/app/examples/shortcuts/index.ts
+++ b/packages/fast-tooling/app/examples/shortcuts/index.ts
@@ -15,6 +15,7 @@ import schemaDictionary from "./schema-dictionary";
 const FASTMessageSystemWorker = require("../../../dist/message-system.min.js");
 const dataElement = document.getElementById("data");
 const inputElement = document.getElementById("input");
+const activeIdElement = document.getElementById("activeid");
 document.body.setAttribute("style", "margin: 0");
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -25,6 +26,10 @@ let dataDictionary;
 
 function handleMessageSystem(e: MessageEvent) {
     if (e.data) {
+        if (e.data.type !== MessageSystemType.custom) {
+            activeIdElement.innerHTML = e.data.activeDictionaryId;
+        }
+
         if (
             e.data.type === MessageSystemType.initialize ||
             e.data.type === MessageSystemType.data

--- a/packages/fast-tooling/src/message-system/message-system.ts
+++ b/packages/fast-tooling/src/message-system/message-system.ts
@@ -106,7 +106,7 @@ export default class MessageSystem<C = {}> {
                 this.messageQueue[0][dataItem[1]] = [];
             }
 
-            this.messageQueue[0][dataItem[1]].push(dataItem[0]); // dataItem[1] is overwritten by the same unique ID
+            this.messageQueue[0][dataItem[1]].push(dataItem[0]);
         });
 
         this.sendNextMessage();
@@ -120,14 +120,18 @@ export default class MessageSystem<C = {}> {
         const firstMessagesInQueue = this.messageQueue[0][firstMessagesId];
 
         if (firstMessagesId && firstMessagesInQueue) {
-            const updatedEvents = firstMessagesInQueue.map(firstMessageInQueue => {
-                return new MessageEvent("message", {
-                    data: firstMessageInQueue,
-                    origin: firstMessageInQueue.origin,
-                    lastEventId: firstMessageInQueue.lastEventId,
-                    source: firstMessageInQueue.source,
+            const updatedEvents = firstMessagesInQueue
+                .filter(firstMessageInQueue => {
+                    return firstMessageInQueue !== null;
+                })
+                .map(firstMessageInQueue => {
+                    return new MessageEvent("message", {
+                        data: firstMessageInQueue,
+                        origin: firstMessageInQueue.origin,
+                        lastEventId: firstMessageInQueue.lastEventId,
+                        source: firstMessageInQueue.source,
+                    });
                 });
-            });
 
             this.register.forEach((registeredItem: Register) => {
                 updatedEvents.forEach(updatedEvent => {

--- a/packages/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.ts
@@ -91,7 +91,7 @@ function getCustomMessage<C, OConfig>(
 function getValidationMessage(
     data: ValidationMessageIncoming,
     historyId: string
-): ValidationMessageOutgoing {
+): ValidationMessageOutgoing | null {
     switch (data.action) {
         case MessageSystemValidationTypeAction.update:
             validation[data.dictionaryId] = data.validationErrors;
@@ -127,6 +127,8 @@ function getValidationMessage(
                 validationErrors: validation[data.dictionaryId],
                 options: data.options,
             };
+        default:
+            return null;
     }
 }
 
@@ -136,7 +138,7 @@ function getValidationMessage(
 function getHistoryMessage(
     data: HistoryMessageIncoming,
     historyId: string
-): Array<HistoryMessageOutgoing | MessageSystemOutgoing> {
+): Array<HistoryMessageOutgoing | MessageSystemOutgoing> | null {
     switch (data.action) {
         case MessageSystemHistoryTypeAction.get:
             return [
@@ -185,6 +187,8 @@ function getHistoryMessage(
                     .flat();
             }
             break;
+        default:
+            return null;
     }
 }
 
@@ -194,7 +198,7 @@ function getHistoryMessage(
 function getSchemaDictionaryMessage(
     data: SchemaDictionaryMessageIncoming,
     historyId: string
-): SchemaDictionaryMessageOutgoing {
+): SchemaDictionaryMessageOutgoing | null {
     switch (data.action) {
         case MessageSystemSchemaDictionaryTypeAction.add:
             schemaDictionary = data.schemas.reduce(
@@ -220,6 +224,8 @@ function getSchemaDictionaryMessage(
                 dictionaryId: activeDictionaryId,
                 validation,
             };
+        default:
+            return null;
     }
 }
 
@@ -419,7 +425,7 @@ function getDataMessage(
     data: DataMessageIncoming,
     linkedDataIds: string[],
     historyId: string
-): XOR<DataMessageOutgoing, ErrorMessageOutgoing> {
+): XOR<DataMessageOutgoing, ErrorMessageOutgoing> | null {
     switch (data.action) {
         case MessageSystemDataTypeAction.duplicate:
             dataDictionary[0][activeDictionaryId].data = getDataWithDuplicate(
@@ -769,6 +775,8 @@ function getDataMessage(
                 validation,
                 options: data.options,
             };
+        default:
+            return null;
     }
 }
 
@@ -789,9 +797,9 @@ function getNavigationPreviousMessage(
                     options: data.options,
                 },
             ];
+        default:
+            return null;
     }
-
-    return null;
 }
 
 /**
@@ -800,7 +808,7 @@ function getNavigationPreviousMessage(
 function getNavigationMessage(
     data: NavigationMessageIncoming,
     historyId: string
-): NavigationMessageOutgoing {
+): NavigationMessageOutgoing | null {
     switch (data.action) {
         case MessageSystemNavigationTypeAction.update:
             activeDictionaryId = data.activeDictionaryId;
@@ -836,6 +844,8 @@ function getNavigationMessage(
                 validation,
                 options: data.options,
             };
+        default:
+            return null;
     }
 }
 
@@ -856,7 +866,7 @@ function updateHistory<C>(
     previous: Array<MessageSystemIncoming<C>> | null,
     id: string,
     historyIndex?: number
-): string | void {
+): void {
     if (previous !== null) {
         /**
          * When history is updated using a historyIndex, it indicates that the history
@@ -881,12 +891,10 @@ function updateHistory<C>(
 
             activeHistoryIndex = historyItemsLength - 1;
         }
-
-        return id;
     }
 }
 
-function getLinkedDataIds(ids: string[], linkedData: Data<unknown>[]) {
+function getLinkedDataIds(ids: string[], linkedData: Data<unknown>[]): void {
     linkedData.map(linkedDataItem => {
         if (Array.isArray(linkedDataItem.linkedData)) {
             getLinkedDataIds(ids, linkedDataItem.linkedData);


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This update ensures that all messages sent back are either outgoing messages or null. This does not include tests as the strict null check should be enabled in the tsconfig, but that is not part of this task.

Another change in this PR is the removal of returning of IDs from the history function, this is because they are never assigned or used.

To better track navigation updates to determine how well shortcuts are working, a small check and indicator has been added to the shortcuts manual testing page.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- More robust testing of the shortcuts to ensure all use cases are covered.