### PR TITLE
Fixed an issue where the HTML render would error if a custom message was sent without an action

### DIFF
--- a/change/@microsoft-fast-tooling-8c563f21-d431-4ba9-88a0-4aa1a9bf5925.json
+++ b/change/@microsoft-fast-tooling-8c563f21-d431-4ba9-88a0-4aa1a9bf5925.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue where the HTML render would error if a custom message was sent without an action",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.ts
@@ -117,8 +117,11 @@ export class HTMLRender extends FoundationElement {
             if (e.data.type === MessageSystemType.navigation) {
                 this.updateSelectedActiveDictionaryId();
             }
-            if (e.data.type === MessageSystemType.custom) {
-                const action: string[] = (e.data.options.action as string).split("::");
+            if (
+                e.data.type === MessageSystemType.custom &&
+                typeof e.data.options?.action === "string"
+            ) {
+                const action: string[] = e.data.options.action.split("::");
                 if (action[0] === "displayMode") {
                     this.interactiveMode = action[1] !== "preview";
                     if (this.interactiveMode) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This PR fixes an issue where if a custom message was sent without an action property it would error.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.