### PR TITLE
Fixed an issue where stopPropagation in HTML Render prevents the use of the shortcuts service

### DIFF
--- a/change/@microsoft-fast-tooling-e42b88de-c742-4d82-a953-0b3084bc9444.json
+++ b/change/@microsoft-fast-tooling-e42b88de-c742-4d82-a953-0b3084bc9444.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue where stopPropagation in HTML Render prevents the use of the shortcuts service",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/fast-tooling/src/web-components/html-render/html-render.ts
@@ -418,7 +418,6 @@ export class HTMLRender extends FoundationElement {
             return true;
         }
         e.preventDefault();
-        e.stopPropagation();
         return false;
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change allows the propagation of keyDown events so that the Shortcuts service can capture all keyDown events.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.