### PR TITLE
Fixes an issue where a single click activity blocked inline editing

### DIFF
--- a/change/@microsoft-fast-tooling-23d510ca-03c5-410c-b434-6f2c9cda1b78.json
+++ b/change/@microsoft-fast-tooling-23d510ca-03c5-410c-b434-6f2c9cda1b78.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an issue where inline editing was blocked when navigation triggers a new selection",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
+++ b/packages/fast-tooling/src/web-components/html-render-layer-inline-edit/html-render-layer-inline-edit.ts
@@ -247,7 +247,10 @@ export class HTMLRenderLayerInlineEdit extends HTMLRenderLayer {
             case ActivityType.click:
                 if (
                     this.currentDataId !== null &&
-                    this.currentDataId !== datadictionaryId
+                    this.currentDataId !== datadictionaryId && // Check that if the text area is active and the selected element is the current element
+                    this.textAreaActive &&
+                    datadictionaryId !==
+                        this.dataDictionary[0][this.currentDataId].parent.id
                 ) {
                     // currently editing and something else was clicked
                     this.cancelEdit();


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This fix checks to see if a single click is on the current elements dictionary ID while it is in inline editing mode. If it is, it will ignore the single click.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
This could use some manual testing vis a vis the automatically deployed site.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
