### PR TITLE
Allow previous data messages for remove to include removing text, useful when removing text from text nodes

### DIFF
--- a/change/@microsoft-fast-tooling-603cb7f5-8129-4f7c-97fa-978fefb9064c.json
+++ b/change/@microsoft-fast-tooling-603cb7f5-8129-4f7c-97fa-978fefb9064c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow previous data messages for remove to include removing text, useful when removing text from text nodes",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/fast-tooling/src/data-utilities/relocate.ts
+++ b/packages/fast-tooling/src/data-utilities/relocate.ts
@@ -172,14 +172,18 @@ function isTargetInArray(dataLocation: string, data: unknown): RelocatedDataConf
 export function getDataUpdatedWithoutSourceData(
     config: UpdateDataWithoutSourceConfig
 ): unknown {
-    const clonedData: unknown = cloneDeep(config.data);
+    let clonedData: unknown = cloneDeep(config.data);
     const sourceDataConfig: RelocatedDataConfig = isTargetInArray(
         config.sourceDataLocation,
         config.data
     );
 
     if (!sourceDataConfig.isArray) {
-        unset(clonedData, config.sourceDataLocation);
+        if (config.sourceDataLocation === "") {
+            clonedData = undefined;
+        } else {
+            unset(clonedData, config.sourceDataLocation);
+        }
     } else {
         const newTargetArray: unknown = get(
             clonedData,

--- a/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -381,6 +381,7 @@ export interface RemoveDataMessageIncoming<TConfig = {}>
     extends ArbitraryMessageIncoming<TConfig> {
     type: MessageSystemType.data;
     action: MessageSystemDataTypeAction.remove;
+    dictionaryId?: string;
     dataLocation: string;
 }
 

--- a/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -1036,6 +1036,82 @@ describe("getMessage", () => {
 
             expect(message[0].data).to.deep.equal({});
         });
+        it("should return a data blob without removed values from a specified dictionary ID", () => {
+            getMessage([
+                {
+                    type: MessageSystemType.initialize,
+                    data: [
+                        {
+                            data: {
+                                schemaId: "foo",
+                                data: {
+                                    foo: "bar",
+                                },
+                            },
+                            data2: {
+                                schemaId: "foo",
+                                data: {
+                                    foo: "bar2",
+                                },
+                            },
+                        },
+                        "data",
+                    ],
+                    schemaDictionary: {
+                        foo: { id: "foo" },
+                    },
+                },
+                "",
+            ]);
+            const message: InternalOutgoingMessage<RemoveDataMessageOutgoing> = getMessage(
+                [
+                    {
+                        type: MessageSystemType.data,
+                        action: MessageSystemDataTypeAction.remove,
+                        dataLocation: "foo",
+                        dictionaryId: "data2",
+                    },
+                    "",
+                ]
+            )[0] as InternalOutgoingMessage<RemoveDataMessageOutgoing>;
+
+            expect(message[0].data).to.deep.equal({});
+            expect(message[0].activeDictionaryId).to.equal("data");
+            expect(message[0].dataDictionary[0].data2.data).to.deep.equal({});
+            expect(message[0].dataDictionary[0].data.data).to.deep.equal({ foo: "bar" });
+        });
+        it("should return a data blob without removed string values", () => {
+            getMessage([
+                {
+                    type: MessageSystemType.initialize,
+                    data: [
+                        {
+                            data: {
+                                schemaId: "foo",
+                                data: "foo",
+                            },
+                        },
+                        "data",
+                    ],
+                    schemaDictionary: {
+                        foo: { id: "foo" },
+                    },
+                },
+                "",
+            ]);
+            const message: InternalOutgoingMessage<RemoveDataMessageOutgoing> = getMessage(
+                [
+                    {
+                        type: MessageSystemType.data,
+                        action: MessageSystemDataTypeAction.remove,
+                        dataLocation: "",
+                    },
+                    "",
+                ]
+            )[0] as InternalOutgoingMessage<RemoveDataMessageOutgoing>;
+
+            expect(message[0].data).to.equal(undefined);
+        });
         it("should return a data blob with added values", () => {
             getMessage([
                 {

--- a/packages/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/fast-tooling/src/message-system/message-system.utilities.ts
@@ -261,10 +261,10 @@ function getDataPreviousMessage(
             ];
         }
         case MessageSystemDataTypeAction.remove: {
-            const dataAtDataLocation = get(
-                dataDictionary[0][activeDictionaryId].data,
-                data.dataLocation
-            );
+            const dataAtDataLocation =
+                data.dataLocation === ""
+                    ? dataDictionary[0][activeDictionaryId].data
+                    : get(dataDictionary[0][activeDictionaryId].data, data.dataLocation);
             const typeofData = typeof dataAtDataLocation;
 
             return [
@@ -306,6 +306,23 @@ function getDataPreviousMessage(
                 typeof data.dictionaryId === "string"
                     ? data.dictionaryId
                     : activeDictionaryId;
+            const updatedData =
+                data.dataLocation === ""
+                    ? dataDictionary[0][dictionaryId].data
+                    : cloneDeep(
+                          get(dataDictionary[0][dictionaryId].data, data.dataLocation)
+                      );
+
+            if (updatedData === undefined) {
+                return [
+                    {
+                        type: MessageSystemType.data,
+                        action: MessageSystemDataTypeAction.remove,
+                        dictionaryId,
+                        dataLocation: data.dataLocation,
+                    },
+                ];
+            }
 
             return [
                 {
@@ -313,9 +330,7 @@ function getDataPreviousMessage(
                     action: MessageSystemDataTypeAction.update,
                     dictionaryId,
                     dataLocation: data.dataLocation,
-                    data: cloneDeep(
-                        get(dataDictionary[0][dictionaryId].data, data.dataLocation)
-                    ),
+                    data: updatedData,
                 },
             ];
         }
@@ -455,10 +470,14 @@ function getDataMessage(
                 validation,
                 options: data.options,
             };
-        case MessageSystemDataTypeAction.remove:
-            dataDictionary[0][activeDictionaryId].data = getDataUpdatedWithoutSourceData({
+        case MessageSystemDataTypeAction.remove: {
+            const dictionaryId =
+                typeof data.dictionaryId === "string"
+                    ? data.dictionaryId
+                    : activeDictionaryId;
+            dataDictionary[0][dictionaryId].data = getDataUpdatedWithoutSourceData({
                 sourceDataLocation: data.dataLocation,
-                data: dataDictionary[0][activeDictionaryId].data,
+                data: dataDictionary[0][dictionaryId].data,
             });
             navigationDictionary = getNavigationDictionary(
                 schemaDictionary,
@@ -469,8 +488,8 @@ function getDataMessage(
             return {
                 type: MessageSystemType.data,
                 action: MessageSystemDataTypeAction.remove,
-                data: dataDictionary[0][activeDictionaryId].data,
-                navigation: navigationDictionary[0][activeDictionaryId],
+                data: dataDictionary[0][dictionaryId].data,
+                navigation: navigationDictionary[0][dictionaryId],
                 dataDictionary,
                 navigationDictionary,
                 activeHistoryIndex,
@@ -482,6 +501,7 @@ function getDataMessage(
                 validation,
                 options: data.options,
             };
+        }
         case MessageSystemDataTypeAction.add:
             dataDictionary[0][activeDictionaryId].data = getDataUpdatedWithSourceData({
                 targetDataLocation: data.dataLocation,


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This change updates the following:
- Allows a previous data message for an update to include removal of strings when it is the root level data type
- Allows remove to include a dictionary ID

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.