### PR TITLE
Add scaffolding for documentation content

### DIFF
--- a/website/docs/examples.md
+++ b/website/docs/examples.md
@@ -1,0 +1,2 @@
+# Examples
+TBD

--- a/website/docs/fast-tooling-react/2.x/components/form.md
+++ b/website/docs/fast-tooling-react/2.x/components/form.md
@@ -1,0 +1,2 @@
+# Form
+TBD

--- a/website/docs/fast-tooling-react/2.x/components/navigation.md
+++ b/website/docs/fast-tooling-react/2.x/components/navigation.md
@@ -1,0 +1,2 @@
+# Navigation
+TBD

--- a/website/docs/fast-tooling-react/2.x/components/viewer.md
+++ b/website/docs/fast-tooling-react/2.x/components/viewer.md
@@ -1,0 +1,2 @@
+# Viewer
+TBD

--- a/website/docs/fast-tooling/0.x/components/color-picker.md
+++ b/website/docs/fast-tooling/0.x/components/color-picker.md
@@ -1,0 +1,2 @@
+# Color Picker
+TBD

--- a/website/docs/fast-tooling/0.x/components/css-box-model.md
+++ b/website/docs/fast-tooling/0.x/components/css-box-model.md
@@ -1,0 +1,2 @@
+# CSS Box Model
+TBD

--- a/website/docs/fast-tooling/0.x/components/css-layout.md
+++ b/website/docs/fast-tooling/0.x/components/css-layout.md
@@ -1,0 +1,2 @@
+# CSS Layout
+TBD

--- a/website/docs/fast-tooling/0.x/components/file.md
+++ b/website/docs/fast-tooling/0.x/components/file.md
@@ -1,0 +1,2 @@
+# File
+TBD

--- a/website/docs/fast-tooling/0.x/components/html-render.md
+++ b/website/docs/fast-tooling/0.x/components/html-render.md
@@ -1,0 +1,2 @@
+# HTML Render
+TBD

--- a/website/docs/fast-tooling/0.x/components/units-text-field.md
+++ b/website/docs/fast-tooling/0.x/components/units-text-field.md
@@ -1,0 +1,2 @@
+# Units Text Field
+TBD

--- a/website/docs/fast-tooling/0.x/message-system-services/create-a-service.md
+++ b/website/docs/fast-tooling/0.x/message-system-services/create-a-service.md
@@ -1,0 +1,2 @@
+# Create a Service
+TBD

--- a/website/docs/fast-tooling/0.x/message-system-services/data-validation.md
+++ b/website/docs/fast-tooling/0.x/message-system-services/data-validation.md
@@ -1,0 +1,2 @@
+# Data Validation
+TBD

--- a/website/docs/fast-tooling/0.x/message-system-services/monaco-editor.md
+++ b/website/docs/fast-tooling/0.x/message-system-services/monaco-editor.md
@@ -1,0 +1,2 @@
+# Monaco Editor
+TBD

--- a/website/docs/fast-tooling/0.x/message-system-services/shortcuts.md
+++ b/website/docs/fast-tooling/0.x/message-system-services/shortcuts.md
@@ -1,0 +1,2 @@
+# Shortcuts
+TBD

--- a/website/docs/fast-tooling/0.x/message-system/data-format.md
+++ b/website/docs/fast-tooling/0.x/message-system/data-format.md
@@ -1,0 +1,2 @@
+# Data Format
+TBD

--- a/website/docs/fast-tooling/0.x/message-system/introduction.md
+++ b/website/docs/fast-tooling/0.x/message-system/introduction.md
@@ -1,1 +1,7 @@
-# Introduction
+# Message System
+
+FAST tooling components rely on including a secondary script which contains a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Worker) called the message system.
+
+This worker performs all of the data manipulation and provides a navigational data structure based on data passed.
+
+TBD

--- a/website/docs/fast-tooling/0.x/message-system/messages.md
+++ b/website/docs/fast-tooling/0.x/message-system/messages.md
@@ -1,0 +1,2 @@
+# Messages
+TBD

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -1,3 +1,3 @@
 # Introduction
 
-Welcome to FAST tooling, an ecosystem of packages which aim to allow live updating of HTML.
+Welcome to FAST tooling, an ecosystem of packages built for the purpose of live updating JSON data.

--- a/website/docs/sidebar.js
+++ b/website/docs/sidebar.js
@@ -1,5 +1,6 @@
 import versions from "./versions.json";
 const toolingPackageName = "@microsoft/fast-tooling";
+const toolingReactPackageName = "@microsoft/fast-tooling-react";
 
 /**
  * The contents of the "documentation" property can either be a "doc" or "category".
@@ -16,6 +17,7 @@ const toolingPackageName = "@microsoft/fast-tooling";
  *   type: "category", // identify this item as a category
  *   label: "Example", // the readable label used in the sidebar UI
  *   path: "path/to/example", // the path to use as an index of items
+ *   description: "" // a description that will show up as a paragraph on the category page
  *   items: [ // the list of items in this category
  *     {
  *       type: "doc", // nesting only goes one level deep, do not place a category type as a category item
@@ -32,14 +34,123 @@ export default {
             path: "introduction",
         },
         {
+            type: "doc",
+            label: "Examples",
+            path: "examples",
+        },
+        {
             type: "category",
             label: "Message System",
+            description:
+                "A web worker that serves as the fundamental backbone to the FAST tooling project.",
             path: "message-system",
             items: [
                 {
                     type: "doc",
                     label: "Introduction",
                     path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system/introduction`,
+                },
+                {
+                    type: "doc",
+                    label: "Messages",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system/messages`,
+                },
+                {
+                    type: "doc",
+                    label: "Data Format",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system/data-format`,
+                },
+            ],
+        },
+        {
+            type: "category",
+            label: "React Components",
+            description:
+                "A set of React components that can be registered with the Message System.",
+            path: "react-components",
+            items: [
+                {
+                    type: "doc",
+                    label: "Form",
+                    path: `fast-tooling-react/${versions[toolingReactPackageName].versions[0]}/components/form`,
+                },
+                {
+                    type: "doc",
+                    label: "Navigation",
+                    path: `fast-tooling-react/${versions[toolingReactPackageName].versions[0]}/components/navigation`,
+                },
+                {
+                    type: "doc",
+                    label: "Viewer",
+                    path: `fast-tooling-react/${versions[toolingReactPackageName].versions[0]}/components/viewer`,
+                },
+            ],
+        },
+        {
+            type: "category",
+            label: "Web Components",
+            description:
+                "A set of FAST-based web components that can be registered with the Message System.",
+            path: "web-components",
+            items: [
+                {
+                    type: "doc",
+                    label: "Color Picker",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/color-picker`,
+                },
+                {
+                    type: "doc",
+                    label: "CSS Box Model",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/css-box-model`,
+                },
+                {
+                    type: "doc",
+                    label: "CSS Layout",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/css-layout`,
+                },
+                {
+                    type: "doc",
+                    label: "File",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/file`,
+                },
+                {
+                    type: "doc",
+                    label: "HTML Render",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/html-render`,
+                },
+                {
+                    type: "doc",
+                    label: "Units Text Field",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/components/units-text-field`,
+                },
+            ],
+        },
+        {
+            type: "category",
+            label: "Message System Services",
+            description:
+                "A set of class-based services that can be registered with the Message System.",
+            path: "message-system-services",
+            items: [
+                {
+                    type: "doc",
+                    label: "Shortcuts",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system-services/shortcuts`,
+                },
+                {
+                    type: "doc",
+                    label: "Monaco Editor",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system-services/monaco-editor`,
+                },
+                {
+                    type: "doc",
+                    label: "Data Validation",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system-services/data-validation`,
+                },
+                {
+                    type: "doc",
+                    label: "Create a Service",
+                    path: `fast-tooling/${versions[toolingPackageName].versions[0]}/message-system-services/create-a-service`,
                 },
             ],
         },

--- a/website/src/templates/content.html
+++ b/website/src/templates/content.html
@@ -1,4 +1,43 @@
 <div class="frontpage">
-    <h1>TBD</h1>
-    <%- baseUrl %>
+    <h1>FAST Tooling</h1>
+    <p>
+        This is the FAST Tooling project, containing a set of packages that can be
+        combined to create complex workflows for web applications. The goal of these
+        workflows is to allow users to create and modify their own web based experiences,
+        from individual web components to completed web sites.
+    </p>
+    <div class="card-container">
+        <div class="card">
+            <h2>Dive in</h2>
+            <p>
+                Get started with our
+                <a href="<%- baseUrl %>/docs/introduction">introduction</a>
+                which will explain the fundamentals of how the tooling ecosystem works and
+                what you need to get going.
+            </p>
+        </div>
+        <div class="card">
+            <h2>Browse our examples</h2>
+            <p>
+                There are a number of components and services available from our packages
+                that can be registered with the message system. To get an overview of how
+                these can be combined, check out our
+                <a href="<%- baseUrl %>/docs/examples">examples</a>
+                .
+            </p>
+        </div>
+        <div class="card">
+            <h2>Create a service</h2>
+            <p>
+                Want to interact with the message system with your own service? To find
+                out more read the page on
+                <a
+                    href="<%- baseUrl %>/docs/fast-tooling/0.x/message-system-services/create-a-service"
+                >
+                    creating a service
+                </a>
+                .
+            </p>
+        </div>
+    </div>
 </div>

--- a/website/src/templates/style/index.html
+++ b/website/src/templates/style/index.html
@@ -85,6 +85,7 @@
         min-width: var(--sidebar-width);
         border-right: 1px solid var(--sidebar-border-color);
         height: calc(100vh - var(--toolbar-height) - var(--footer-height) - 30px);
+        overflow: auto;
     }
 
     .sidebar nav {
@@ -126,10 +127,16 @@
         color: var(--link-color);
     }
 
-    a {
+    .category a,
+    .toolbar a,
+    .sidebar a,
+    footer a {
         display: flex;
         align-items: center;
         column-gap: 5px;
+    }
+
+    a {
         color: var(--link-color);
         text-decoration: none;
     }
@@ -158,6 +165,22 @@
 
     .frontpage {
         margin: var(--spacing-vertical);
+    }
+
+    .card-container {
+        display: flex;
+        flex-wrap: wrap;
+        column-gap: 15px;
+        row-gap: 15px;
+        justify-content: center;
+        margin: 50px 0;
+    }
+
+    .card {
+        background: var(--background-color-layer-3);
+        border-radius: 5px;
+        padding: 0 20px;
+        width: 300px;
     }
 
     .mobile-overlay {


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!--- Provide some background and a description of your work. -->
This PR adds blank pages (and some style enhancements) to the documentation website. These are to be filled out one at a time after this PR is complete. The scaffolding should give an idea of the approach for how a user might visit the documentation site and interact with it.

Reliant on https://github.com/microsoft/fast-tooling/pull/203

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.
-->
Note that this change does not update the generated HTML in the `docs/` folder, this will only be done via a workflow dispatch.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Create workflow for generating documentation and committing it to the repository